### PR TITLE
Change to pre-release version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@condenast/launch-vehicle-fbm",
+  "name": "launch-vehicle-fbm",
   "version": "1.0.0-0",
   "description": "An event driven SDK for Facebook Messenger chat bots.",
   "main": "src/index.js",


### PR DESCRIPTION
## Why are we doing this?

Pre-releases in Node are denoted by `-0` suffixes. This allows npm to
tell the difference from a version installed from Git versus the
released code. Ideally the only commits inside Git without the
pre-release suffix are the tagged commits.