### PR TITLE
Remove quiz bot specific messages

### DIFF
--- a/messages.js
+++ b/messages.js
@@ -1,14 +1,11 @@
 // Similar to a 'messages.pot' for internationalization
 module.exports = {
-  quiz_loaded: 'Quizzes loaded',
+  // When an array is provided, text translation will choose an item at random
   catch_all: [
     'catch all number one',
     'catch all number two',
     'catch all number three'
   ],
-  // You can't .split() unicode, but spread works
-  // https://ponyfoo.com/articles/es6-strings-and-unicode-in-depth
-  emoji: [...'💋😂😽'],
-  help: 'This is the help message',
-  pong: 'PONG!'
+  hello: 'This is the greeting message',
+  help: 'This is the help message'
 };


### PR DESCRIPTION
## Why are we doing this?

Removing translations specific to the quiz bot that the SDK was ported from. Also adding a `hello` example, and a comment on how the arrays are utilized.

## Did you document your work?

`README` already covers the necessary docs on the translation and the added inline comment helps with context on the array examples.

## How can someone test these changes?

One would have to set up a bot and use the translations to fully validate these changes.

## What possible risks or adverse effects are there?

None identified.

## What are the follow-up tasks?

None identified.

## Are there any known issues?

No.

## Did the test coverage decrease?

No.