### PR TITLE
Fix package.json warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,17 +14,17 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/CondeNast/rkt-beauty-lenses.git"
+    "url": "git+https://github.com/CondeNast/launch-vehicle-fbm.git"
   },
   "keywords": [
     "facebook", "messenger", "bot", "sdk"
   ],
   "author": "Condé Nast Partnerships Team",
-  "license": "Copyright Condé Nast",
+  "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/CondeNast/rkt-pop-quiz-hotshot/issues"
+    "url": "https://github.com/CondeNast/launch-vehicle-fbm/issues"
   },
-  "homepage": "https://github.com/CondeNast/rkt-pop-quiz-hotshot#readme",
+  "homepage": "https://github.com/CondeNast/launch-vehicle-fbm#readme",
   "dependencies": {
     "bluebird": "^3.4.7",
     "body-parser": "^1.16.0",


### PR DESCRIPTION
## Why are we doing this?

There were some broken windows in the package.json that this PR patches up:
* `npm WARN launch-vehicle-fbm@1.0.0-0 license should be a valid SPDX license expression`
* wrong links

## Did you document your work?

Fixes some broken documentation

## How can someone test these changes?

Steps to manually verify the change:

1. `npm install`
2. `npm test`
3. The SPDX license warning should not show

## What possible risks or adverse effects are there?

none

## What are the follow-up tasks?

none

## Are there any known issues?

nope

## Did the test coverage decrease?

n/a