### PR TITLE
Conversion of conversation logger to a standalone module

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -1,5 +1,6 @@
 {
   "launch-vehicle-fbm": {
+    "dashBotKey": "DASHBOT_KEY",
     "facebook": {
       "appId": "FACEBOOK_APP_ID",
       "pageId": "FACEBOOK_PAGE_ID"
@@ -10,6 +11,10 @@
       "validationToken": "MESSENGER_VALIDATION_TOKEN"
     },
     "port": "NODE_PORT",
-    "serverUrl": "SERVER_URL"
+    "serverUrl": "SERVER_URL",
+    "slack": {
+      "channel": "SLACK_CHANNEL",
+      "webhookUrl": "SLACK_WEBHOOK_URL"
+    }
   }
 }

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -12,9 +12,7 @@
     },
     "port": "NODE_PORT",
     "serverUrl": "SERVER_URL",
-    "slack": {
-      "channel": "SLACK_CHANNEL",
-      "webhookUrl": "SLACK_WEBHOOK_URL"
-    }
+    "slackChannel": "SLACK_CHANNEL",
+    "slackWebhookUrl": "SLACK_WEBHOOK_URL"
   }
 }

--- a/example.env
+++ b/example.env
@@ -11,5 +11,4 @@ MESSENGER_VALIDATION_TOKEN=validate_me
 MESSENGER_PAGE_ACCESS_TOKEN=ThatsAReallyLongStringYouGotThere
 MODIFACE_API_URL=http://localhost:5000
 SERVER_URL=https://localhost/
-SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T123456/B33Z/Pajamas
 LOG_FILE=/var/log/beauty-lenses/chat.log

--- a/example.env
+++ b/example.env
@@ -11,4 +11,6 @@ MESSENGER_VALIDATION_TOKEN=validate_me
 MESSENGER_PAGE_ACCESS_TOKEN=ThatsAReallyLongStringYouGotThere
 MODIFACE_API_URL=http://localhost:5000
 SERVER_URL=https://localhost/
+SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T123456/B33Z/Pajamas
+SLACK_CHANNEL=channel
 LOG_FILE=/var/log/beauty-lenses/chat.log

--- a/src/app.js
+++ b/src/app.js
@@ -32,7 +32,7 @@ class Messenger extends EventEmitter {
   constructor({hookPath = '/webhook', linkPath = '/link', emitGreetings = true} = {}) {
     super();
 
-    this.conversationLogger = new ConversationLogger();
+    this.conversationLogger = new ConversationLogger(config);
 
     this.options = {
       hookPath,

--- a/src/app.js
+++ b/src/app.js
@@ -32,7 +32,7 @@ class Messenger extends EventEmitter {
   constructor({hookPath = '/webhook', linkPath = '/link', emitGreetings = true} = {}) {
     super();
 
-    this.conversationLogger = new ConversationLogger(config);
+    this.conversationLogger = new ConversationLogger();
 
     this.options = {
       hookPath,

--- a/src/app.js
+++ b/src/app.js
@@ -14,7 +14,7 @@ const reqPromise = require('request-promise');
 const urlJoin = require('url-join');
 
 const config = require('./config');
-const conversationLogger = require('./conversationLogger');
+const { ConversationLogger } = require('./conversationLogger');
 
 const cache = new Cacheman('sessions');
 
@@ -31,6 +31,8 @@ class Messenger extends EventEmitter {
   /*:: greetings: RegExp */
   constructor({hookPath = '/webhook', linkPath = '/link', emitGreetings = true} = {}) {
     super();
+
+    this.conversationLogger = new ConversationLogger(config);
 
     this.options = {
       hookPath,
@@ -68,7 +70,7 @@ class Messenger extends EventEmitter {
 
     this.app.post(hookPath, (req, res) => {
       const data = req.body;
-      conversationLogger.logIncoming(data);
+      this.conversationLogger.logIncoming(data);
       // `data` reference:
       // https://developers.facebook.com/docs/messenger-platform/webhook-reference#format
       if (data.object === 'page') {
@@ -345,7 +347,7 @@ class Messenger extends EventEmitter {
 
     return reqPromise.post(options)
       .then((jsonObj) => {
-        conversationLogger.logOutgoing(options, jsonObj);
+        this.conversationLogger.logOutgoing(options, jsonObj);
         const {recipient_id: recipientId, message_id: messageId} = jsonObj;
         debug('message.send:SUCCESS message id: %s to user:%d', messageId, recipientId);
       })

--- a/src/conversationLogger.js
+++ b/src/conversationLogger.js
@@ -3,29 +3,25 @@ const dashbot = require('dashbot');
 const winston = require('winston');
 const Slack = require('winston-slack-transport');
 
-const config = require('./config');
-
 class ConversationLogger {
-  /*:: options: Object */
-  constructor() {
-
+  constructor(options) {
     this.logger = new (winston.Logger)({transports: []});
+    this.options = options;
 
-    if (config.has('logFile')) {
+    if (this.options.logFile) {
       this.logger.add(winston.transports.File, {
-        filename: config.get('logFile'),
+        filename: this.options.logFile,
         json: true
       });
     }
-    this.dashbotClient = config.has('dashBotKey') ? dashbot(config.get('dashBotKey')).facebook : false;
+    this.dashbotClient = this.options.dashBotKey ? dashbot(this.options.dashBotKey).facebook : false;
 
-    if (config.has('slack.webhookUrl') && config.has('slack.channel')) {
+    if (this.options.slackWebhookUrl && this.options.slackChannel) {
       this.logger.add(Slack, {
-        webhook_url: config.get('slack.webhookUrl'),
+        webhook_url: this.options.slackWebhookUrl,
         username: 'Chat Spy',
         custom_formatter: this.slackFormatter
       });
-      this.slackChannel = config.get('slack.channel');
     }
   }
 
@@ -56,7 +52,7 @@ class ConversationLogger {
     }
 
     return {
-      channel: this.slackChannel,
+      channel: this.options.slackChannel,
       icon_url: `https://robohash.org/${meta.userId}.png`,
       username: meta.userId,
       text: addressee + text

--- a/src/conversationLogger.js
+++ b/src/conversationLogger.js
@@ -1,12 +1,19 @@
+// @flow
 // A knockoff of Dashbot's API for generic conversation logging
 const dashbot = require('dashbot');
 const winston = require('winston');
 const Slack = require('winston-slack-transport');
 
 class ConversationLogger {
-  constructor(options) {
+  /*:: options: Object */
+  constructor({dashBotKey, logFile, slackChannel, slackWebhookUrl} = {}) {
     this.logger = new (winston.Logger)({transports: []});
-    this.options = options;
+    this.options = {
+      dashBotKey,
+      logFile,
+      slackChannel,
+      slackWebhookUrl
+    };
 
     if (this.options.logFile) {
       this.logger.add(winston.transports.File, {
@@ -25,7 +32,7 @@ class ConversationLogger {
     }
   }
 
-  slackFormatter(level, msg, meta) {
+  slackFormatter(level/*: string */, msg/*: Object */, meta/*: Object */) {
     // console.log(JSON.stringify(meta));  // enable for DEBUG
     const addressee = meta.userId === meta.recipientId ? '' : '> ';
     let text = '```' + JSON.stringify(meta, undefined, 2) + '\n```';
@@ -59,7 +66,7 @@ class ConversationLogger {
     };
   }
 
-  logIncoming(requestBody) {
+  logIncoming(requestBody/*: Object */) {
     if (this.dashbotClient) {
       this.dashbotClient.logIncoming(requestBody);
     }
@@ -75,7 +82,7 @@ class ConversationLogger {
     }, data.message || {}, data.postback || {}));
   }
 
-  logOutgoing(requestData, responseBody) {
+  logOutgoing(requestData/*: Object */, responseBody/*: Object */) {
     if (this.dashbotClient) {
       // TODO should we strip pageAccessToken before giving it to dashbotClient?
       // Dashbot probably uses it to get profile information

--- a/src/conversationLogger.js
+++ b/src/conversationLogger.js
@@ -3,9 +3,11 @@ const dashbot = require('dashbot');
 const winston = require('winston');
 const Slack = require('winston-slack-transport');
 
+const config = require('./config');
+
 class ConversationLogger {
   /*:: options: Object */
-  constructor(config) {
+  constructor() {
 
     this.logger = new (winston.Logger)({transports: []});
 

--- a/src/conversationLogger.js
+++ b/src/conversationLogger.js
@@ -7,7 +7,7 @@ const Slack = require('winston-slack-transport');
 class ConversationLogger {
   /*:: options: Object */
   constructor({dashBotKey, logFile, slackChannel, slackWebhookUrl} = {}) {
-    this.logger = new (winston.Logger)({transports: []});
+    this.logger = new winston.Logger({transports: []});
     this.options = {
       dashBotKey,
       logFile,
@@ -76,6 +76,7 @@ class ConversationLogger {
       return;
     }
 
+    // TODO: rewrite? postbacks came along and were shoved in
     this.logger.info(Object.assign({
       userId: data.sender.id,
       senderId: data.sender.id

--- a/src/conversationLogger.js
+++ b/src/conversationLogger.js
@@ -3,90 +3,92 @@ const dashbot = require('dashbot');
 const winston = require('winston');
 const Slack = require('winston-slack-transport');
 
-const logger = new (winston.Logger)({transports: []});
+class ConversationLogger {
+  /*:: options: Object */
+  constructor(config) {
 
-if (process.env.LOG_FILE) {
-  logger.add(winston.transports.File, {
-    filename: process.env.LOG_FILE,
-    json: true
-  });
-}
+    this.logger = new (winston.Logger)({transports: []});
 
-const dashbotClient = process.env.DASHBOT_KEY ? dashbot(process.env.DASHBOT_KEY).facebook : false;
-
-function slackFormatter(level, msg, meta) {
-  // console.log(JSON.stringify(meta));  // enable for DEBUG
-  const addressee = meta.userId === meta.recipientId ? '' : '> ';
-  let text = '```' + JSON.stringify(meta, undefined, 2) + '\n```';
-  if (meta.text) {
-    text = meta.text;
-  } else if (meta.payload) {
-    text = '`' + meta.payload + '`';
-  } else if (meta.attachment) {
-    if (meta.attachment.type === 'template') {
-      text = meta.attachment.payload.elements.map((element) => element.title).join('\n');
-    } else if (meta.attachment.payload.url) {
-      text = meta.attachment.payload.url;
-    } else {
-      text = `Unknown meta.attachment: \`${JSON.stringify(meta.attachment)}\``;
+    if (config.has('logFile')) {
+      this.logger.add(winston.transports.File, {
+        filename: config.get('logFile'),
+        json: true
+      });
     }
-  } else if (meta.attachments) {
-    text = meta.attachments.map((attachment) => {
-      if (attachment.payload && attachment.payload.url) {
-        return attachment.payload.url;
+    this.dashbotClient = config.has('dashBotKey') ? dashbot(config.get('dashBotKey')).facebook : false;
+
+    if (config.has('slack.webhookUrl') && config.has('slack.channel')) {
+      this.logger.add(Slack, {
+        webhook_url: config.get('slack.webhookUrl'),
+        username: 'Chat Spy',
+        custom_formatter: this.slackFormatter
+      });
+      this.slackChannel = config.get('slack.channel');
+    }
+  }
+
+  slackFormatter(level, msg, meta) {
+    // console.log(JSON.stringify(meta));  // enable for DEBUG
+    const addressee = meta.userId === meta.recipientId ? '' : '> ';
+    let text = '```' + JSON.stringify(meta, undefined, 2) + '\n```';
+    if (meta.text) {
+      text = meta.text;
+    } else if (meta.payload) {
+      text = '`' + meta.payload + '`';
+    } else if (meta.attachment) {
+      if (meta.attachment.type === 'template') {
+        text = meta.attachment.payload.elements.map((element) => element.title).join('\n');
+      } else if (meta.attachment.payload.url) {
+        text = meta.attachment.payload.url;
       } else {
-        return 'Unknown meta.attachments[]: `' + JSON.stringify(attachment) + '`';
+        text = `Unknown meta.attachment: \`${JSON.stringify(meta.attachment)}\``;
       }
-    }).join('\n');
+    } else if (meta.attachments) {
+      text = meta.attachments.map((attachment) => {
+        if (attachment.payload && attachment.payload.url) {
+          return attachment.payload.url;
+        } else {
+          return 'Unknown meta.attachments[]: `' + JSON.stringify(attachment) + '`';
+        }
+      }).join('\n');
+    }
+
+    return {
+      channel: this.slackChannel,
+      icon_url: `https://robohash.org/${meta.userId}.png`,
+      username: meta.userId,
+      text: addressee + text
+    };
   }
 
-  return {
-    channel: process.env.SLACK_CHANNEL,
-    icon_url: `https://robohash.org/${meta.userId}.png`,
-    username: meta.userId,
-    text: addressee + text
-  };
-}
+  logIncoming(requestBody) {
+    if (this.dashbotClient) {
+      this.dashbotClient.logIncoming(requestBody);
+    }
+    const data = requestBody.entry[0].messaging[0];
+    if (!(data.postback || data.message)) {
+      // console.log(JSON.stringify(data));  // enable for DEBUG
+      return;
+    }
 
-if (process.env.SLACK_WEBHOOK_URL && process.env.SLACK_CHANNEL) {
-  logger.add(Slack, {
-    webhook_url: process.env.SLACK_WEBHOOK_URL,
-    username: 'Chat Spy',
-    custom_formatter: slackFormatter
-  });
-}
-
-
-function logIncoming(requestBody) {
-  if (dashbotClient) {
-    dashbotClient.logIncoming(requestBody);
-  }
-  const data = requestBody.entry[0].messaging[0];
-  if (!(data.postback || data.message)) {
-    // console.log(JSON.stringify(data));  // enable for DEBUG
-    return;
+    this.logger.info(Object.assign({
+      userId: data.sender.id,
+      senderId: data.sender.id
+    }, data.message || {}, data.postback || {}));
   }
 
-  logger.info(Object.assign({
-    userId: data.sender.id,
-    senderId: data.sender.id
-  }, data.message || {}, data.postback || {}));
-}
-
-function logOutgoing(requestData, responseBody) {
-  if (dashbotClient) {
-    // TODO should we strip pageAccessToken before giving it to dashbotClient?
-    // Dashbot probably uses it to get profile information
-    dashbotClient.logOutgoing(requestData, responseBody);
+  logOutgoing(requestData, responseBody) {
+    if (this.dashbotClient) {
+      // TODO should we strip pageAccessToken before giving it to dashbotClient?
+      // Dashbot probably uses it to get profile information
+      this.dashbotClient.logOutgoing(requestData, responseBody);
+    }
+    this.logger.info(Object.assign({
+      recipientId: requestData.json.recipient.id,
+      userId: requestData.json.recipient.id,
+      mid: responseBody.message_id
+    }, requestData.json.message));
   }
-  logger.info(Object.assign({
-    recipientId: requestData.json.recipient.id,
-    userId: requestData.json.recipient.id,
-    mid: responseBody.message_id
-  }, requestData.json.message));
 }
 
-exports.logger = logger;
-exports.logIncoming = logIncoming;
-exports.logOutgoing = logOutgoing;
-exports.slackFormatter = slackFormatter;
+exports.ConversationLogger = ConversationLogger;

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -10,7 +10,7 @@ const app = require('../src/app');
 chai.use(chaiHttp);
 
 describe('app', () => {
-  const messenger = new app.Messenger(config);
+  const messenger = new app.Messenger();
   let session;
 
   beforeEach(() => {

--- a/test/conversationLogger.spec.js
+++ b/test/conversationLogger.spec.js
@@ -1,10 +1,11 @@
 const assert = require('assert');
-const config = require('config');
 const sinon = require('sinon');
 const { ConversationLogger } = require('../src/conversationLogger');
 
+const config = require('config').get('launch-vehicle-fbm');
+
 describe('conversationLogger', () => {
-  const conversationLogger = new ConversationLogger();
+  const conversationLogger = new ConversationLogger(config);
   const logger = conversationLogger.logger;  // shorter alias
 
   beforeEach(() => {

--- a/test/conversationLogger.spec.js
+++ b/test/conversationLogger.spec.js
@@ -4,7 +4,7 @@ const sinon = require('sinon');
 const { ConversationLogger } = require('../src/conversationLogger');
 
 describe('conversationLogger', () => {
-  const conversationLogger = new ConversationLogger(config.get('launch-vehicle-fbm'));
+  const conversationLogger = new ConversationLogger();
   const logger = conversationLogger.logger;  // shorter alias
 
   beforeEach(() => {

--- a/test/conversationLogger.spec.js
+++ b/test/conversationLogger.spec.js
@@ -1,8 +1,10 @@
 const assert = require('assert');
+const config = require('config');
 const sinon = require('sinon');
-const conversationLogger = require('../src/conversationLogger');
+const { ConversationLogger } = require('../src/conversationLogger');
 
 describe('conversationLogger', () => {
+  const conversationLogger = new ConversationLogger(config.get('launch-vehicle-fbm'));
   const logger = conversationLogger.logger;  // shorter alias
 
   beforeEach(() => {


### PR DESCRIPTION
## Why are we doing this?

`ConversationLoggger` is a viable, stand-alone, (open source)? module and this does some cleanup that will help maintainability and open to the door to it being separated from the SDK should we decide that in the future.

## Did you document your work?

No additional documentation added. There is no standalone `README` for this and these changes are all internal to the SDK so nothing that is currently documented in the `README` changes. The minimal changes to the tests should back this up.

## How can someone test these changes?

`npm i`
`npm t`

Testing against a skeleton bot:
* link this library via `npm link`
* use [this gist] as a test bot
* run the bot!

[this gist]: https://gist.github.com/stripethree/3fa81ea549957502bd0c1b7b85ae5abf

## What possible risks or adverse effects are there?

While this PR touts decoupling this as a standalone module, the configuration namespacing is still tied to the SDK. Thus, it also adds additional configuration elements; these do not have to be present and `has` is used in the `ConversationLogger` constructor to prevent exceptions from bubbling up. `Messenger` does not access any of the `ConversationLogger` configuration items.

## What are the follow-up tasks?

* Do we want to decouple this from Messenger entirely?
* Do we want to have this be event driven?

## Are there any known issues?

None identified; ~~integration testing pending~~.

## Did the test coverage decrease?

No.