### PR TITLE
Doc just enough to link back to a Prior Art wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,3 +179,11 @@ Optional environment variables:
    [dashbot]: https://www.dashbot.io/
    [winston]: https://github.com/winstonjs/winston
    [webhook url]: https://api.slack.com/incoming-webhooks
+
+
+Prior art
+---------
+
+There are many other Messenger Node packages; we made a page to help you decide
+if this is the appropriate one for your project:
+https://github.com/CondeNast/launch-vehicle-fbm/wiki/Prior-art


### PR DESCRIPTION
## Why are we doing this?

In the Node ecosystem, there are a lot of packages that all do kinda the same thing. I appreciate when a READMEs document similar packages and what the differences are from an expert's point of view. It turns out that for Messenger, it would be hard to maintain this in the README, so this PR adds a link to a new wiki page where that information can be kept.

Closes #13 

## Did you document your work?

The wiki page seems decent, nothing wrong with starting small.

## How can someone test these changes?

View the rendered version of the README in Github. The link should work and go to https://github.com/CondeNast/launch-vehicle-fbm/wiki/Prior-art

## What possible risks or adverse effects are there?

Time progresses and information gets out of date, eventually becoming unhelpful.

## What are the follow-up tasks?

none

## Are there any known issues?

non

## Did the test coverage decrease?

N/A