### PR TITLE
Fix how this.options was referencing wrong object in conversationLogger

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -26,9 +26,11 @@ const DEFAULT_GREETINGS_REGEX = /^(get started|good(morning|afternoon)|hello|hey
 const DEFAULT_HELP_REGEX = /^help\b/i;
 
 class Messenger extends EventEmitter {
-  /*:: options: Object */
   /*:: app: Object */
+  /*:: conversationLogger: Object */
   /*:: greetings: RegExp */
+  /*:: help: RegExp */
+  /*:: options: Object */
   constructor({hookPath = '/webhook', linkPath = '/link', emitGreetings = true} = {}) {
     super();
 

--- a/src/conversationLogger.js
+++ b/src/conversationLogger.js
@@ -5,6 +5,8 @@ const winston = require('winston');
 const Slack = require('winston-slack-transport');
 
 class ConversationLogger {
+  /*:: dashbotClient: ?Object */
+  /*:: logger: winston.Logger */
   /*:: options: Object */
   constructor({dashBotKey, logFile, slackChannel, slackWebhookUrl} = {}) {
     this.logger = new winston.Logger({transports: []});
@@ -21,13 +23,13 @@ class ConversationLogger {
         json: true
       });
     }
-    this.dashbotClient = this.options.dashBotKey ? dashbot(this.options.dashBotKey).facebook : false;
+    this.dashbotClient = this.options.dashBotKey ? dashbot(this.options.dashBotKey).facebook : null;
 
     if (this.options.slackWebhookUrl && this.options.slackChannel) {
       this.logger.add(Slack, {
         webhook_url: this.options.slackWebhookUrl,
         username: 'Chat Spy',
-        custom_formatter: this.slackFormatter
+        custom_formatter: this.slackFormatter.bind(this)
       });
     }
   }


### PR DESCRIPTION
## Why are we doing this?

In the conversation logger refactor #23 , a global options became an instance attribute `this.options`. Unfortunately, because Winston calls `this.slackFormatter` and not the `ConversationLogger` instance, `this.options` changed unexpectedly to reference the Winston logger and was `undefined` when we meant for it to reference `ConversationLogger.options`.

## Did you document your work?

Some additional Flow type docs added while trying to debug this.

## How can someone test these changes?

Steps to manually verify the change:

1. Run the bot in a dev environment (`npm link`)
2. You don't need to enable Slack config, but it's nice
3. Messaging the bot should not result in a `TypeError: Cannot read property 'slackChannel' of undefined`

## What possible risks or adverse effects are there?

* I may have missed another `this` for something else, but we can tackle that when it shows

## What are the follow-up tasks?

* none

## Are there any known issues?

none

## Did the test coverage decrease?

Increases with Flow type. Unfortunately, the integration with Winston is still uncovered because we don't have integration tests for this, just unit tests.