### PR TITLE
Make response factories easier to access

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ const messenger = new Messenger();
 messenger.on('text', ({senderId, text}) => {
   if (text.includes('corgis')) {
     messenger.send(senderId, new Text('aRf aRf!'))
-      .then(() => messenger.send(senderId, new Image('http://i.imgur.com/izwcQLS.jpg')));
+      .then(() => messenger.send(senderId, new Image('https://i.imgur.com/izwcQLS.jpg')));
   }
 });
 messenger.start();
@@ -122,13 +122,13 @@ The most common response is text:
 
 Images just need a url. These also show up in the "Shared Photos" rail.
 
-    new Image('http://i.imgur.com/ehSTCkO.gif')
+    new Image('https://i.imgur.com/ehSTCkO.gif')
 
 There are a few others that are supported too:
 
 * `new Generic(elements[])`
   https://developers.facebook.com/docs/messenger-platform/send-api-reference/generic-template
-* `new ImageQuickReply('http://i.imgur.com/ehSTCkO.gif', quickReplies[])` NOTE: the syntax for quick replies may change in the future since it's orthogonal to `Text` and `Image`.
+* `new ImageQuickReply('https://i.imgur.com/ehSTCkO.gif', quickReplies[])` NOTE: the syntax for quick replies may change in the future since it's orthogonal to `Text` and `Image`.
 https://developers.facebook.com/docs/messenger-platform/send-api-reference/quick-replies
 
 

--- a/README.md
+++ b/README.md
@@ -35,14 +35,16 @@ example.
 We emit a variety of events. Attach listeners like:
 ```javascript
 // General form
-messenger.on(eventName, ({dataItem1, dataItem2}) => {});
-
-// Example
-messenger.on('text', ({text}) => {
-  if (text.indexOf('corgis') !== -1) {
-    console.log('aRf aRf!');
+// messenger.on(eventName, ({dataItem1, dataItem2}) => {});
+const { Messenger, Text, Image } = require('launch-vehicle-fbm');
+const messenger = new Messenger();
+messenger.on('text', ({senderId, text}) => {
+  if (text.includes('corgis')) {
+    messenger.send(senderId, new Text('aRf aRf!'))
+      .then(() => messenger.send(senderId, new Image('http://i.imgur.com/izwcQLS.jpg')));
   }
 });
+messenger.start();
 ```
 
 The event name and what's in the `data` for each event handler:
@@ -107,6 +109,13 @@ The event name and what's in the `data` for each event handler:
 
 ### Sending responses to the user
 
+Some factories for generating responses are available at the top level and are
+also available in a `responses` object if you need a namespace:
+
+    const { Text, Image, Generic, ImageQuickReply } = require('launch-vehicle-fbm');
+    const { responses } = require('launch-vehicle-fbm');
+    // responses.Text, responses.Image, etc.
+
 The most common response is text:
 
     new Text('Hello World')
@@ -117,10 +126,10 @@ Images just need a url. These also show up in the "Shared Photos" rail.
 
 There are a few others that are supported too:
 
-* `new ImageReply('http://i.imgur.com/ehSTCkO.gif', quickReplies[])`
-  https://developers.facebook.com/docs/messenger-platform/send-api-reference/quick-replies
 * `new Generic(elements[])`
   https://developers.facebook.com/docs/messenger-platform/send-api-reference/generic-template
+* `new ImageQuickReply('http://i.imgur.com/ehSTCkO.gif', quickReplies[])` NOTE: the syntax for quick replies may change in the future since it's orthogonal to `Text` and `Image`.
+https://developers.facebook.com/docs/messenger-platform/send-api-reference/quick-replies
 
 
 #### `Text` translation

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Usage
 -----
 
 ```javascript
-const { Messenger } = require('./src/messenger');
+const { Messenger } = require('launch-vehicle-fbm');
 const messenger = new Messenger(options);
 messenger.start();  // Start listening
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,10 @@
 const { Messenger } = require('./app');
+const responses = require('./responses');
 
-module.exports.Messenger = Messenger;
+exports.Messenger = Messenger;
+
+exports.responses = responses;
+
+exports.Text = responses.Text;
+exports.Image = responses.Image;
+exports.Generic = responses.Generic;

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ exports.Messenger = Messenger;
 
 exports.responses = responses;
 
-exports.Text = responses.Text;
-exports.Image = responses.Image;
 exports.Generic = responses.Generic;
+exports.Image = responses.Image;
+exports.ImageQuickReply = responses.ImageQuickReply;
+exports.Text = responses.Text;

--- a/src/responses.js
+++ b/src/responses.js
@@ -1,6 +1,6 @@
 // @flow
 const fs = require('fs');
-const debug = require('debug')('messenger:objects');
+const debug = require('debug')('messenger:responses');
 
 const appRootDir = require('app-root-dir').get();
 if (fs.existsSync(`${appRootDir}/messages.js`)) {

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -1,0 +1,13 @@
+const assert = require('assert');
+
+const main = require('..');
+
+
+describe('main', () => {
+  it('publicly exposes things', () => {
+    assert.equal(typeof main.Messenger, 'function');
+    assert.equal(typeof main.responses, 'object');
+    assert.equal(typeof main.Text, 'function');
+    assert.equal(typeof main.responses.Text, 'function');
+  });
+});

--- a/test/responses.spec.js
+++ b/test/responses.spec.js
@@ -4,36 +4,36 @@ const path = require('path');
 const appRootDir = require('app-root-dir');
 const sinon = require('sinon');
 
-const objects = require('../src/objects');
-const Text = objects.Text;
+const responses = require('../src/responses');
+const Text = responses.Text;
 
 
-describe('Messenger Objects', () => {
+describe('Responses', () => {
   let originalDictionary;
 
   before(() => {
-    originalDictionary = objects._dictionary;
+    originalDictionary = responses._dictionary;
   });
 
   after(() => {
-    objects._dictionary = originalDictionary;
+    responses._dictionary = originalDictionary;
   });
 
   describe('dictionary', () => {
     it('loads an empty dictionary when messages are not found', () => {
-      assert.deepEqual(objects._dictionary, {});
+      assert.deepEqual(responses._dictionary, {});
     });
 
     it('loads a dictionary', () => {
-      const objectsRef = Object.keys(require.cache).find((x) => x.endsWith('/src/objects.js'));
-      delete require.cache[objectsRef];
+      const responsesRef = Object.keys(require.cache).find((x) => x.endsWith('/src/responses.js'));
+      delete require.cache[responsesRef];
       sinon.stub(appRootDir, 'get').returns(path.resolve(path.join(__dirname, './fixtures')));
 
-      const dictionary = require('../src/objects')._dictionary;
+      const dictionary = require('../src/responses')._dictionary;
 
       assert.equal(dictionary.greeting_msg, 'Hello World!');
 
-      delete require.cache[objectsRef];
+      delete require.cache[responsesRef];
       appRootDir.get.restore();
     });
   });
@@ -55,13 +55,13 @@ describe('Messenger Objects', () => {
     });
 
     it('uses translation', () => {
-      objects._dictionary = {tmnt: 'Teenage Mutant Ninja Turtles'};
+      responses._dictionary = {tmnt: 'Teenage Mutant Ninja Turtles'};
       const text = new Text('tmnt');
       assert.strictEqual(text.text, 'Teenage Mutant Ninja Turtles');
     });
 
     it('picks a random element if translation is an array', () => {
-      objects._dictionary = {tmnt: ['Teenage Mutant Ninja Turtles']};
+      responses._dictionary = {tmnt: ['Teenage Mutant Ninja Turtles']};
       const text = new Text('tmnt');
       assert.strictEqual(text.text, 'Teenage Mutant Ninja Turtles');
     });


### PR DESCRIPTION
## Why are we doing this?

Currently, if users want to use the response object factories, they have to reach into the source (which also currently requires knowledge of the source tree). This adds documentation for how to use them and also makes them easier to access.

closes #21 

## Did you document your work?

Some major rework of the README

## How can someone test these changes?

Steps to manually verify the change:

Just unit tests (`main.spec.js`). You can npm link this in to a side project but that's going above what you should need to do to test this.

## What possible risks or adverse effects are there?

* none

## What are the follow-up tasks?

* I noted that quick replies are still a WIP, so we'll have to revisit that one day

## Are there any known issues?

* If the user assumes they can tree shake `require('launch-vehicle-fbm/responses/Text')`, they'll be sad. But this isn't documented so that's ok.

## Did the test coverage decrease?

new code is covered