### PR TITLE
Kill killswitch for events that come in via message_echoes

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ The event name and what's in the `data` for each event handler:
 
   [postback]: https://developers.facebook.com/docs/messenger-platform/webhook-reference/postback-received
 
+#### A special note about echo events
+
+If you enable `message_echoes` in your [Messenger webhooks], you'll get bot
+messages too. You'll need to examine `event.message.is_echo` in your handlers.
+
+[Messenger webhooks]: https://developers.facebook.com/docs/messenger-platform/webhook-reference#setup
 
 ### Sending responses to the user
 

--- a/package.json
+++ b/package.json
@@ -44,12 +44,12 @@
     "winston-slack-transport": "^2.0.0"
   },
   "devDependencies": {
-    "@condenast/eslint-config-condenast": "^0.7.0",
+    "@condenast/eslint-config-condenast": "^0.9.1",
     "chai": "^3.5.0",
     "chai-http": "^3.0.0",
     "eslint": "^3.15.0",
-    "eslint-plugin-import": "^1.16.0",
-    "flow-bin": "^0.39.0",
+    "eslint-plugin-import": "^2.2.0",
+    "flow-bin": "^0.41.0",
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0",
     "sinon": "^1.17.6"

--- a/src/app.js
+++ b/src/app.js
@@ -240,19 +240,11 @@ class Messenger extends EventEmitter {
     debug('onMessage from user:%d with message: %j', senderId, message);
 
     const {
-      metadata,
       quick_reply: quickReply,
       // You may get text or attachments but not both
       text,
       attachments
     } = message;
-
-    if (message.is_echo) {
-      // Requires enabling `message_echoes` in your webhook, which is not the default
-      // https://developers.facebook.com/docs/messenger-platform/webhook-reference#setup
-      debug('message.echo metadata: %s', metadata);
-      return;
-    }
 
     if (this.options.emitGreetings && this.greetings.test(text)) {
       const firstName = session.profile.first_name.trim();

--- a/src/app.js
+++ b/src/app.js
@@ -127,13 +127,13 @@ class Messenger extends EventEmitter {
           // The page does not have a public profile and calling the Graph API here will always yield a 400.
           session.profile = {};
           return session;
-        } else {
-          return this.getPublicProfile(messagingEvent.sender.id)
-            .then((profile) => {
-              session.profile = profile;
-              return session;
-            });
         }
+
+        return this.getPublicProfile(messagingEvent.sender.id)
+          .then((profile) => {
+            session.profile = profile;
+            return session;
+          });
       })
       .then((session) => {
         session.count++;

--- a/src/conversationLogger.js
+++ b/src/conversationLogger.js
@@ -54,9 +54,9 @@ class ConversationLogger {
       text = meta.attachments.map((attachment) => {
         if (attachment.payload && attachment.payload.url) {
           return attachment.payload.url;
-        } else {
-          return 'Unknown meta.attachments[]: `' + JSON.stringify(attachment) + '`';
         }
+
+        return 'Unknown meta.attachments[]: `' + JSON.stringify(attachment) + '`';
       }).join('\n');
     }
 


### PR DESCRIPTION
## Why are we doing this?

To enable two bots one page for a new conversation logger, you need the ability to make a bot that can listen to echo messages. Otherwise, the observer bot can only observe humans.

After talking through #34, the double opt-in seemed excessive. This PR solves the same problem, but with only one opt-in, and so less code.

closes #29

## Did you document your work?

README now talks about echo messages

## How can someone test these changes?

Steps to manually verify the change:

1.  Edit the webhook for a bot to get echos too
2. view the log to see more events come in

## What possible risks or adverse effects are there?

* none. If a user gets echos and it triggers things, then the app should either stop listening to echos and/or they should check the echo themselves.

## What are the follow-up tasks?

* none

## Are there any known issues?

none

## Did the test coverage decrease?

stays the same. code was deleted, and that code wasn't really covered, so... maybe this increases coverage?