### PR TITLE
Fix session timeouts

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -16,9 +16,9 @@ const urlJoin = require('url-join');
 const config = require('./config');
 const { ConversationLogger } = require('./conversationLogger');
 
-const cache = new Cacheman('sessions');
-
 const SESSION_TIMEOUT_MS = 3600 * 1000;  // 1 hour
+
+const cache = new Cacheman('sessions', {ttl: SESSION_TIMEOUT_MS / 1000});
 
 const internals = {};
 


### PR DESCRIPTION
## Why are we doing this?

This is a copy paste of a fix that wasn't copy pasted into the initial SDK. Cacheman has a default TTL of [60 seconds](https://github.com/cayasso/cacheman/blob/6149f436268cedbec54633c81481ae7035411873/lib/index.js#L99-L104) but [it's not documented](https://github.com/cayasso/cacheman/issues/37). This meant if you took a break in the middle of a quiz, it would freeze on you.

## Did you document your work?

This explicitly sets the TTL, which increases documentation

## How can someone test these changes?

Can't test within the SDK, but this is a copy paste

## What possible risks or adverse effects are there?

* Uptime
* Security
* Performance degradation
* Data loss

If applicable, include a technical debt note. Do a quick estimate of if this pull request increases or decreases technical debt. Leave a message to future developers about why increased technical debt is worth it, or brag about how you figured out how to reduce technical debt.

## What are the follow-up tasks?

* Make setting the session length a constructor option to the SDK

## Are there any known issues?

None

## Did the test coverage decrease?

same, initial values to cacheman are not part of the test suite.