### PR TITLE
Add printf-like formatting to Text response helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,10 +144,14 @@ https://developers.facebook.com/docs/messenger-platform/send-api-reference/quick
 `messages.js` in its root. Using this sample:
 
     module.exports = {
-      greeting_msg: 'Hello World!'
+      greeting_msg: 'Hello World!',
+      error_count: 'Errors found: %d'
     };
 
 `new Text('greeting_msg')` would be equivalent of doing `new Text('Hello World!')`.
+You can also use `printf`-like syntax, like:
+* `new Text('error_count', 12)`
+* `new Text('I have %d %s', 20, 'cabbages')`
 
 [gettext]: https://en.wikipedia.org/wiki/Gettext
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "debug": "^2.6.0",
     "express": "^4.14.1",
     "express-handlebars": "^3.0.0",
-    "request": "^2.79.0",
+    "request": "^2.81.0",
     "request-promise": "^4.1.1",
     "url-join": "^1.1.0",
     "winston": "^2.3.1",
@@ -52,6 +52,6 @@
     "flow-bin": "^0.41.0",
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0",
-    "sinon": "^1.17.6"
+    "sinon": "^2.0.0"
   }
 }

--- a/src/responses.js
+++ b/src/responses.js
@@ -1,5 +1,6 @@
 // @flow
 const fs = require('fs');
+const { format } = require('util');
 const debug = require('debug')('messenger:responses');
 
 const appRootDir = require('app-root-dir').get();
@@ -19,23 +20,23 @@ if (fs.existsSync(`${appRootDir}/messages.js`)) {
 class Text {
   /*:: codetext: string */
   /*:: text: string */
-  // TODO printf support so you can do new Text('You answered %d', count)
-  // https://nodejs.org/docs/latest/api/util.html#util_util_format_format_args
-  constructor(text/*: string */) {
+  constructor(text/*: string */, ...args/*: mixed[] */) {
     Object.defineProperty(this, 'codetext', {
       enumerable: false,  // This is the default, but here to be explicit
       value: text
     });
     const translation = exports._dictionary[text];
+    let newText;
     if (translation) {
       if (Array.isArray(translation)) {
-        this.text = translation[0 | Math.random() * translation.length];
+        newText = translation[0 | Math.random() * translation.length];
       } else {
-        this.text = translation;
+        newText = translation;
       }
     } else {
-      this.text = text;
+      newText = text;
     }
+    this.text = format(newText, ...args);
   }
 }
 

--- a/test/responses.spec.js
+++ b/test/responses.spec.js
@@ -65,5 +65,12 @@ describe('Responses', () => {
       const text = new Text('tmnt');
       assert.strictEqual(text.text, 'Teenage Mutant Ninja Turtles');
     });
+
+    it('supports printf formatting', () => {
+      responses._dictionary = {'tmn%s': 'Teenage Mutant Ninja %s'};
+      const text = new Text('tmn%s', 'Turtles');
+      assert.strictEqual(text.text, 'Teenage Mutant Ninja Turtles');
+    });
+
   });
 });

--- a/test/responses.spec.js
+++ b/test/responses.spec.js
@@ -72,5 +72,16 @@ describe('Responses', () => {
       assert.strictEqual(text.text, 'Teenage Mutant Ninja Turtles');
     });
 
+    it('supports printf formatting when dictionary entry missing', () => {
+      responses._dictionary = {};
+      const text = new Text('tmn%s', 'Turtles');
+      assert.strictEqual(text.text, 'tmnTurtles');
+    });
+
+    it('concatenates additional arguments', () => {
+      responses._dictionary = {};
+      const text = new Text('tmn', 'Turtles');
+      assert.strictEqual(text.text, 'tmn Turtles');
+    });
   });
 });

--- a/test/responses.spec.js
+++ b/test/responses.spec.js
@@ -72,6 +72,12 @@ describe('Responses', () => {
       assert.strictEqual(text.text, 'Teenage Mutant Ninja Turtles');
     });
 
+    it('supports printf formatting with obfuscated format string', () => {
+      responses._dictionary = {tmnt: 'Teenage Mutant Ninja %s'};
+      const text = new Text('tmnt', 'Turtles');
+      assert.strictEqual(text.text, 'Teenage Mutant Ninja Turtles');
+    });
+
     it('supports printf formatting when dictionary entry missing', () => {
       responses._dictionary = {};
       const text = new Text('tmn%s', 'Turtles');


### PR DESCRIPTION
## Why are we doing this?

The text translation helps us write smaller code, but if you need to do special formatting, like "Fetched %d out of %d", you currently have to write out the whole string yourself, which can lead to very long lines, which is one of the major reasons why the `Text` translation layer exists in the first place. This adds [`util.format`](https://nodejs.org/docs/latest/api/util.html#util_util_format_format_args) to `Text` so it knows how to do this kind of formatting in a way that's consistent with `console` and printf and gettext.

closes #22

## Did you document your work?

New functionality is in the README and there are test cases for some edge cases where I wondered what would happen.

## How can someone test these changes?

Steps to manually verify the change:

Since this is in the SDK, there's only unit tests unless you `npm link` in and do a manual test. I trusted the test cases.

2. `npm i`
3. `npm t`

## What possible risks or adverse effects are there?

There is a computation cost in adding `util.format`. It may also be unnatural when `%` naturally occurs in your text

## What are the follow-up tasks?

* roll a release

## Are there any known issues?

none

## Did the test coverage decrease?

stays the same