### PR TITLE
Document session.profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,11 +171,17 @@ The SDK sets some values in the session:
 
 * `count`: `int` how many events have been received from this user
 * `lastSeen`: `int` The time (in milliseconds since epoch time) we last saw activity
-* `source`: `String`|`undefined` A guess of where the user came from for this session:
+* `profile`: `Object`, the profile as retrieved from Facebook Messenger. [See the docs][user-profile] for the most up to date information. If a profile can't be pulled, it's `{}`, otherwise, here are some of the more useful fields for quick reference:
+  * `profile.first_name`: first name
+  * `profile.last_name`: last name
+  * `profile.profile_pic`: profile picture
+* `source`: `string|undefined` A guess of where the user came from for this session:
   * `direct` TODO, not implemented yet
   * `return` A returning visitor
   * `web` Came from a "Send to Messenger" button on a website
   * `undefined` Unknown
+
+[user-profile]: https://developers.facebook.com/docs/messenger-platform/user-profile
 
 
 Logging and metrics

--- a/README.md
+++ b/README.md
@@ -52,47 +52,47 @@ The event name and what's in the `data` for each event handler:
 * `message` Any kind of message event. This is sent in addition to the events for specific message types.
   * `event` The raw event
   * `senderId` The ID of the sender
-  * `session` A Session object you can mutate
+  * `session` [A Session object](#the-session-object) you can mutate
   * `message` Direct access to `event.message`
 * `text` Text message
   * `event` The raw event
   * `senderId` The ID of the sender
-  * `session` A Session object you can mutate
+  * `session` [A Session object](#the-session-object) you can mutate
   * `source` One of `quickReply`, `postback`, `text`
   * `text` Message content, `event.message.text` for text events, `payload` for `postback` and `quickReply` events
 * `text.greeting` (optional, defaults to enabled) Text messages that match common greetings
   * `event` The raw event
   * `senderId` The ID of the sender
-  * `session` A Session object you can mutate
+  * `session` [A Session object](#the-session-object) you can mutate
   * `firstName` Trimmed first name from the user's public Facebook profile
   * `surName` Trimmed first name from the user's public Facebook profile
   * `fullName` Concatenating of `firstName` and `surName` with a single, separating space
 * `text.help` (optional, defaults to enabled) Text messages that match requests for assistance
   * `event` The raw event
   * `senderId` The ID of the sender
-  * `session` A Session object you can mutate
+  * `session` [A Session object](#the-session-object) you can mutate
 * `message.image` Image (both attached and from user's camera)
   * `event` The raw event
   * `senderId` The ID of the sender
-  * `session` A Session object you can mutate
+  * `session` [A Session object](#the-session-object) you can mutate
   * `url` Direct access to `event.message.attachments[0].payload.url` for the url of the image
 * `message.sticker` Sticker
   * `event` The raw event
   * `senderId` The ID of the sender
-  * `session` A Session object you can mutate
+  * `session` [A Session object](#the-session-object) you can mutate
 * `message.thumbsup` User clicked the "thumbsup"/"like" button
   * `event` The raw event
   * `senderId` The ID of the sender
-  * `session` A Session object you can mutate
+  * `session` [A Session object](#the-session-object) you can mutate
 * `message.text` For conversation, use the `text` event
   * `event` The raw event
   * `senderId` The ID of the sender
-  * `session` A Session object you can mutate
+  * `session` [A Session object](#the-session-object) you can mutate
   * `text` Message content, `event.message.text` for text events
 * `message.quickReply` For conversation, use the `text` event, this is for the raw message sent via a quick reply button
   * `event` The raw event
   * `senderId` The ID of the sender
-  * `session` A Session object you can mutate
+  * `session` [A Session object](#the-session-object) you can mutate
   * `source` One of `quickReply`, `postback`, `text`
   * `payload` Quick reply content, `event.quick_reply.payload`
 * `postback` For conversation, use the `text` event, this is for the raw message sent via a postback

--- a/src/app.js
+++ b/src/app.js
@@ -89,6 +89,8 @@ class Messenger extends EventEmitter {
     });
 
     // App routes
+
+    // Stub routes for future functionality
     this.app.get('/login', (req, res) => res.render('login', {
       appId: config.get('facebook.appId'),
       serverUrl: config.get('serverUrl')


### PR DESCRIPTION
## Why are we doing this?

This is a documentation update for some missing information. I tried looking for it in the past assuming it was there. Since `session.profile` is provided by the SDK, it's worth writing something even if it does just point to Facebook's docs.

closes #32 

## Did you document your work?

this is it

## How can someone test these changes?

Steps to manually verify the change:

1. view the [rendered readme](https://github.com/CondeNast/launch-vehicle-fbm/blob/d9fc92ec34948b257bb9699613ddc2411b188c7f/README.md)
2. clicking on a hotlinked "a session object" should take you to the session docs

## What possible risks or adverse effects are there?

* increases docs tech debt, but I managed to cop out by trying to get people to go to the official docs for more info

## What are the follow-up tasks?

none

## Are there any known issues?

N/A

## Did the test coverage decrease?

N/A