### PR TITLE
Store the page id for conversations in the session

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -195,7 +195,7 @@ class Messenger extends EventEmitter {
     this.send(senderId, messageData);
   }
 
-  getPublicProfile(senderId/*: number */) {
+  getPublicProfile(senderId/*: number */)/*: Promise<Object> */ {
     const options = {
       json: true,
       qs: {

--- a/src/app.js
+++ b/src/app.js
@@ -118,7 +118,7 @@ class Messenger extends EventEmitter {
     });
   }
 
-  routeEachMessage(messagingEvent/*: Object */, pageId/*: string */) {
+  routeEachMessage(messagingEvent/*: Object */, pageId/*: string */)/*: Promise<Session> */ {
     const cacheKey = this.getCacheKey(messagingEvent.sender.id);
     return cache.get(cacheKey)
       .then((session/*: Session */ = {_key: cacheKey, _pageId: pageId, count: 0, profile: null}) => {
@@ -319,11 +319,11 @@ class Messenger extends EventEmitter {
   // HELPERS
   //////////
 
-  getCacheKey(senderId/*: number */) {
+  getCacheKey(senderId/*: number */)/*: string */ {
     return `${config.get('facebook.appId')}-${senderId}`;
   }
 
-  saveSession(session/*: Object */) {
+  saveSession(session/*: Object */)/*: Promise<Session> */ {
     return cache.set(session._key, session);
   }
 

--- a/src/app.js
+++ b/src/app.js
@@ -77,7 +77,7 @@ class Messenger extends EventEmitter {
       // https://developers.facebook.com/docs/messenger-platform/webhook-reference#format
       if (data.object === 'page') {
         data.entry.forEach((pageEntry) => {
-          pageEntry.messaging.forEach(this.routeEachMessage.bind(this));
+          pageEntry.messaging.forEach((x) => this.routeEachMessage(x, pageEntry.id));
         });
         res.sendStatus(200);
       }
@@ -116,14 +116,14 @@ class Messenger extends EventEmitter {
     });
   }
 
-  routeEachMessage(messagingEvent/*: Object */) {
+  routeEachMessage(messagingEvent/*: Object */, pageId/*: string */) {
     const cacheKey = this.getCacheKey(messagingEvent.sender.id);
     return cache.get(cacheKey)
       .then((session = {_key: cacheKey, count: 0}) => {
         // WISHLIST: logic to handle any thundering herd issues: https://en.wikipedia.org/wiki/Thundering_herd_problem
         if (session.profile) {
           return session;
-        } else if (messagingEvent.sender.id === config.get('facebook.pageId')) {
+        } else if (messagingEvent.sender.id === pageId) {
           // The page does not have a public profile and calling the Graph API here will always yield a 400.
           session.profile = {};
           return session;

--- a/src/app.js
+++ b/src/app.js
@@ -121,7 +121,7 @@ class Messenger extends EventEmitter {
   routeEachMessage(messagingEvent/*: Object */, pageId/*: string */) {
     const cacheKey = this.getCacheKey(messagingEvent.sender.id);
     return cache.get(cacheKey)
-      .then((session/*: Session */ = {_key: cacheKey, count: 0, profile: null}) => {
+      .then((session/*: Session */ = {_key: cacheKey, _pageId: pageId, count: 0, profile: null}) => {
         // WISHLIST: logic to handle any thundering herd issues: https://en.wikipedia.org/wiki/Thundering_herd_problem
         if (session.profile) {
           return session;

--- a/src/app.js
+++ b/src/app.js
@@ -25,6 +25,8 @@ const internals = {};
 const DEFAULT_GREETINGS_REGEX = /^(get started|good(morning|afternoon)|hello|hey|hi|hola|what's up)/i;
 const DEFAULT_HELP_REGEX = /^help\b/i;
 
+/*:: type Session = {count: number, profile: ?Object} */
+
 class Messenger extends EventEmitter {
   /*:: app: Object */
   /*:: conversationLogger: Object */
@@ -119,7 +121,7 @@ class Messenger extends EventEmitter {
   routeEachMessage(messagingEvent/*: Object */, pageId/*: string */) {
     const cacheKey = this.getCacheKey(messagingEvent.sender.id);
     return cache.get(cacheKey)
-      .then((session = {_key: cacheKey, count: 0}) => {
+      .then((session/*: Session */ = {_key: cacheKey, count: 0, profile: null}) => {
         // WISHLIST: logic to handle any thundering herd issues: https://en.wikipedia.org/wiki/Thundering_herd_problem
         if (session.profile) {
           return session;
@@ -212,7 +214,7 @@ class Messenger extends EventEmitter {
   // EVENTS
   /////////
 
-  onAuth(event, session) {
+  onAuth(event, session/*: Session */) {
     const senderId = event.sender.id;
     // The 'ref' is the data passed through the 'Send to Messenger' call
     const optinRef = event.optin.ref;
@@ -232,7 +234,7 @@ class Messenger extends EventEmitter {
     return;
   }
 
-  onMessage(event, session) {
+  onMessage(event, session/*: Session */) {
     const senderId = event.sender.id;
     const {message} = event;
 
@@ -247,8 +249,8 @@ class Messenger extends EventEmitter {
     } = message;
 
     if (this.options.emitGreetings && this.greetings.test(text)) {
-      const firstName = session.profile.first_name.trim();
-      const surName = session.profile.last_name.trim();
+      const firstName = session.profile && session.profile.first_name.trim() || '';
+      const surName = session.profile && session.profile.last_name.trim() || '';
       const fullName = `${firstName} ${surName}`;
 
       this.emit('text.greeting', {event, senderId, session, firstName, surName, fullName});
@@ -301,7 +303,7 @@ class Messenger extends EventEmitter {
     }
   }
 
-  onPostback(event, session) {
+  onPostback(event, session/*: Session */) {
     const senderId = event.sender.id;
 
     // The 'payload' param is a developer-defined field which is set in a postback

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -395,11 +395,26 @@ describe('app', () => {
 
     afterEach(() => {
       messenger.getPublicProfile.restore();
+      return app.__internals__.cache.clear();
     });
+
+    it('sets _key', () =>
+      messenger.routeEachMessage(baseMessage)
+        .then((session) => {
+          assert.ok(session._key);
+        })
+    );
+
+    it('sets _pageId', () =>
+      messenger.routeEachMessage(baseMessage, '12345')
+        .then((session) => {
+          assert.equal(session._pageId, '12345');
+        })
+    );
 
     it('counts every message received', () =>
       messenger.routeEachMessage(baseMessage)
-        .then(() => messenger.routeEachMessage(baseMessage))
+        .then(() => messenger.routeEachMessage(baseMessage, '123'))
         .then((session) => {
           assert.equal(session.count, 2);
         })

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -437,21 +437,14 @@ describe('app', () => {
     });
 
     describe('return user', () => {
-      let originalValue;
-
-      before(() => {
-        originalValue = app.__internals__.SESSION_TIMEOUT_MS;
-        app.__internals__.SESSION_TIMEOUT_MS = 0;
-      });
-
-      after(() => {
-        app.__internals__.SESSION_TIMEOUT_MS = originalValue;
-      });
-
       it('sets source for return user', () =>
         messenger.routeEachMessage(baseMessage)
           .then((session) => {
             session.source = 'foo';
+            session.lastSeen = 1;
+            return messenger.saveSession(session);
+          })
+          .then(() => {
             return messenger.routeEachMessage(baseMessage);
           })
           .then((session) => {


### PR DESCRIPTION
## Why are we doing this?

The long term goal is to have one bot service multiple pages. To do that, we need to associate conversations with a page. Lucky for us, we have the `session` storage around. This PR:
* adds an internal `_pageId` to the session object
* adds some Flow type documentation I wish existed to document some function signatures
* fixes some leaky tests

This is a precursor to #30

## Did you document your work?

The session object doesn't require a README update because it's internal. There are new Flow docs. Functionality and the API does not change.

## How can someone test these changes?

Just unit tests. I also ran this `npm link`ed to another bot and it ran as usual.

## What possible risks or adverse effects are there?

* minor: increases the payload and responsibility of the session object

## What are the follow-up tasks?

* #30 Sending based on page id
* major rework of page id/page access token config

## Are there any known issues?

none

## Did the test coverage decrease?

new code is covered, 
increases with flow coverage
improves exiting tests