### PR TITLE
Add ability to bring your own cache storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ If you want to customize the cache, you can supply your own cache in the
 `Messenger` constructor. By default, it uses the [cacheman] memory cache, but
 any cache that follows these simple patterns will work:
 
-* `cache.get(key: string): Promise<Object>`
+* `cache.get(key: string): ?Promise<Object>`
 * `cache.set(key: string, value: Object): Promise<Object>`
 
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ messenger.start();  // Start listening
 
 ### Options
 
-* `port` (default: `3000`)
+* `cache` (default: [cacheman] memory cache) See [Session cache](#session-cache)
 * `hookPath` (default: `/webhook`)
 * `linkPath` (default: `/link`)
+* `port` (default: `3000`)
 * `emitGreetings` (default: true)
   When enabled, emits common greetings as `text.greeting` events.
   When disabled, no check is run and `text` events will be emitted.
@@ -184,6 +185,17 @@ The SDK sets some values in the session:
 [user-profile]: https://developers.facebook.com/docs/messenger-platform/user-profile
 
 
+Session cache
+-------------
+
+If you want to customize the cache, you can supply your own cache in the
+`Messenger` constructor. By default, it uses the [cacheman] memory cache, but
+any cache that follows these simple patterns will work:
+
+* `cache.get(key: string): Promise<Object>`
+* `cache.set(key: string, value: Object): Promise<Object>`
+
+
 Logging and metrics
 -------------------
 
@@ -193,7 +205,6 @@ Logging and metrics
    specifically to let us recreate/monitor conversations.
 
 Optional environment variables:
-
 
 * `DASHBOT_KEY` - If this is present, [dashbot] integration will be on
 * `LOG_FILE` – [winston] will log conversations to this file. It should be an absolute path

--- a/README.md
+++ b/README.md
@@ -196,6 +196,13 @@ any cache that follows these simple patterns will work:
 * `cache.set(key: string, value: Object): Promise<Object>`
 
 
+Other APIs
+---------
+
+* `require('launch-vehicle-fbm').SESSION_TIMEOUT_MS`: This constant is available if you need some sort of magic number for what to consider a session length
+* `Messenger.app`: The base Express app is available for you here
+
+
 Logging and metrics
 -------------------
 

--- a/package.json
+++ b/package.json
@@ -44,12 +44,12 @@
     "winston-slack-transport": "^2.0.0"
   },
   "devDependencies": {
-    "@condenast/eslint-config-condenast": "^0.9.1",
+    "@condenast/eslint-config-condenast": "^0.10.0",
     "chai": "^3.5.0",
     "chai-http": "^3.0.0",
-    "eslint": "^3.15.0",
+    "eslint": "^3.19.0",
     "eslint-plugin-import": "^2.2.0",
-    "flow-bin": "^0.41.0",
+    "flow-bin": "^0.43.0",
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0",
     "sinon": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "chai-http": "^3.0.0",
     "eslint": "^3.19.0",
     "eslint-plugin-import": "^2.2.0",
-    "flow-bin": "^0.43.0",
+    "flow-bin": "^0.43.1",
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0",
     "sinon": "^2.0.0"

--- a/src/app.js
+++ b/src/app.js
@@ -16,10 +16,8 @@ const urlJoin = require('url-join');
 const config = require('./config');
 const { ConversationLogger } = require('./conversationLogger');
 
+
 const SESSION_TIMEOUT_MS = 3600 * 1000;  // 1 hour
-
-
-const internals = {};
 
 const DEFAULT_GREETINGS_REGEX = /^(get started|good(morning|afternoon)|hello|hey|hi|hola|what's up)/i;
 const DEFAULT_HELP_REGEX = /^help\b/i;
@@ -129,6 +127,7 @@ class Messenger extends EventEmitter {
   routeEachMessage(messagingEvent/*: Object */, pageId/*: string */)/*: Promise<Session> */ {
     const cacheKey = this.getCacheKey(messagingEvent.sender.id);
     return this.cache.get(cacheKey)
+      // .then((cacheResult) => cacheResult || undefined)
       .then((session/*: Session */ = {_key: cacheKey, _pageId: pageId, count: 0, profile: null}) => {
         // WISHLIST: logic to handle any thundering herd issues: https://en.wikipedia.org/wiki/Thundering_herd_problem
         if (session.profile) {
@@ -149,8 +148,7 @@ class Messenger extends EventEmitter {
         session.count++;
         if (session.source !== 'return' &&
             session.lastSeen &&
-            // have to use `internals` here for testability
-            new Date().getTime() - session.lastSeen > internals.SESSION_TIMEOUT_MS) {
+            new Date().getTime() - session.lastSeen > exports.SESSION_TIMEOUT_MS) {
           session.source = 'return';
         }
         session.lastSeen = new Date().getTime();
@@ -377,6 +375,5 @@ class Messenger extends EventEmitter {
   }
 }
 
-internals.SESSION_TIMEOUT_MS = SESSION_TIMEOUT_MS;
-exports.__internals__ = internals;
+exports.SESSION_TIMEOUT_MS = SESSION_TIMEOUT_MS;
 exports.Messenger = Messenger;

--- a/src/app.js
+++ b/src/app.js
@@ -327,7 +327,7 @@ class Messenger extends EventEmitter {
   //////////
 
   getCacheKey(senderId/*: number */)/*: string */ {
-    return `${config.get('facebook.appId')}-${senderId}`;
+    return '' + senderId;
   }
 
   saveSession(session/*: Object */)/*: Promise<Session> */ {

--- a/src/app.js
+++ b/src/app.js
@@ -127,6 +127,8 @@ class Messenger extends EventEmitter {
   routeEachMessage(messagingEvent/*: Object */, pageId/*: string */)/*: Promise<Session> */ {
     const cacheKey = this.getCacheKey(messagingEvent.sender.id);
     return this.cache.get(cacheKey)
+      // The cacheman-redis backend returns `null` instead of `undefined`
+      .then((cacheResult) => cacheResult || undefined)
       .then((session/*: Session */ = {_key: cacheKey, _pageId: pageId, count: 0, profile: null}) => {
         // WISHLIST: logic to handle any thundering herd issues: https://en.wikipedia.org/wiki/Thundering_herd_problem
         if (session.profile) {

--- a/src/app.js
+++ b/src/app.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 const EventEmitter = require('events');
 
 const bodyParser = require('body-parser');
@@ -38,17 +38,17 @@ class Messenger extends EventEmitter {
 
     this.conversationLogger = new ConversationLogger(config);
 
-    this.options = {
-      hookPath,
-      linkPath
-    };
-
     if (emitGreetings instanceof RegExp) {
       this.greetings = emitGreetings;
     } else {
       this.greetings = DEFAULT_GREETINGS_REGEX;
     }
-    this.options.emitGreetings = !!emitGreetings;
+
+    this.options = {
+      emitGreetings: !!emitGreetings,
+      hookPath,
+      linkPath
+    };
 
     this.app = express();
     this.app.engine('handlebars', exphbs({defaultLayout: 'main'}));

--- a/src/app.js
+++ b/src/app.js
@@ -127,7 +127,6 @@ class Messenger extends EventEmitter {
   routeEachMessage(messagingEvent/*: Object */, pageId/*: string */)/*: Promise<Session> */ {
     const cacheKey = this.getCacheKey(messagingEvent.sender.id);
     return this.cache.get(cacheKey)
-      // .then((cacheResult) => cacheResult || undefined)
       .then((session/*: Session */ = {_key: cacheKey, _pageId: pageId, count: 0, profile: null}) => {
         // WISHLIST: logic to handle any thundering herd issues: https://en.wikipedia.org/wiki/Thundering_herd_problem
         if (session.profile) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
-const { Messenger } = require('./app');
+const { Messenger, SESSION_TIMEOUT_MS } = require('./app');
 const responses = require('./responses');
 
+exports.SESSION_TIMEOUT_MS = SESSION_TIMEOUT_MS;
 exports.Messenger = Messenger;
 
 exports.responses = responses;

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -407,20 +407,22 @@ describe('app', () => {
       messenger.getPublicProfile.restore();
     });
 
-    it.only('uses default session if cache returns falsey', () => {
+    it('uses default session if cache returns falsey', () => {
       const nullCache = {
         get() {
           return Promise.resolve(null);
         },
-        set() {
+        set(key, data) {
+          return Promise.resolve(data);
         }
       };
       messenger = new Messenger({cache: nullCache});
+      sinon.stub(messenger, 'getPublicProfile').resolves({});
 
       return messenger.routeEachMessage(baseMessage)
         .then((session) => {
           assert.ok(session._key);
-        })  ;
+        });
     });
 
     it('sets _key', () =>

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -407,6 +407,22 @@ describe('app', () => {
       messenger.getPublicProfile.restore();
     });
 
+    it.only('uses default session if cache returns falsey', () => {
+      const nullCache = {
+        get() {
+          return Promise.resolve(null);
+        },
+        set() {
+        }
+      };
+      messenger = new Messenger({cache: nullCache});
+
+      return messenger.routeEachMessage(baseMessage)
+        .then((session) => {
+          assert.ok(session._key);
+        })  ;
+    });
+
     it('sets _key', () =>
       messenger.routeEachMessage(baseMessage)
         .then((session) => {

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -32,6 +32,14 @@ describe('app', () => {
     messenger.send.restore && messenger.send.restore();
   });
 
+  describe('constructor', () => {
+    it('can use a supplied cache instead of the default', () => {
+      const fakeCache = {};
+      const messenger = new Messenger({cache: fakeCache});
+      assert.strictEqual(messenger.cache, fakeCache);
+    });
+  });
+
   describe('doLogin', function () {
     this.timeout(100);
     it('emits login event', () => {


### PR DESCRIPTION
## Why are we doing this?

We need to expand the session cache to live outside the current memory cache. This PR adjusts the `Messenger` constructor to take in a new optional option: `cache`. If supplied, `Messenger` will use this new cache instead of the default.

Some other changes:
* refactor to reduce Flow type warnings
* refactor to remove `__internals__` hack
* remove unnecessary namespacing that the redis cache backend handles already

closes #47 
closes #41 (makes this obsolete)
closes #45 (documentation)

## Did you document your work?

The readme documents the basics of how to supply your own cache. If the cacheman-redis library were more elegant, I'd include an example but it's very awkward to use so I opted to punt on including an example to avoid including a confusing example.

## How can someone test these changes?

Steps to manually verify the change:

1. `npm i`
2. `npm t`
3. you can also `npm link` this and verify that your bot behaves the same.

## What possible risks or adverse effects are there?

* none. This does open another way for the user to shoot themselves in the foot though.

## What are the follow-up tasks?

* document an example. Perhaps just a dummy cache example?

## Are there any known issues?

None

## Did the test coverage decrease?

There's a weird behavior the redis cache does where it returns `null` which then throws off the default parameters. There's code added to workaround when a cache backend does this along with tests.
