### PR TITLE
Add plumbing for page specific operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ messenger.start();  // Start listening
 * `cache` (default: [cacheman] memory cache) See [Session cache](#session-cache)
 * `hookPath` (default: `/webhook`)
 * `linkPath` (default: `/link`)
+* `pages`: A map of page ids to page access tokens `{1029384756: 'ThatsAReallyLongStringYouGotThere'}`. Currently optional but config will migrate to this in the future
 * `port` (default: `3000`)
 * `emitGreetings` (default: true)
   When enabled, emits common greetings as `text.greeting` events.
@@ -116,12 +117,18 @@ messages too. You'll need to examine `event.message.is_echo` in your handlers.
 
 ### Sending responses to the user
 
-Some factories for generating responses are available at the top level and are
-also available in a `responses` object if you need a namespace:
+Send responses back to the user like:
+
+    messenger.send(senderId, responseObject, [pageId])
+
+But this syntax will be deprecated for a simpler version in the future.
+
+Some factories for generating `responseObject` are available at the top level and
+are also available in a `responses` object if you need a namespace:
 
     const { Text, Image, Generic, ImageQuickReply } = require('launch-vehicle-fbm');
     const { responses } = require('launch-vehicle-fbm');
-    // responses.Text, responses.Image, etc.
+    // responses.Text, responses.Image, responses.Generic, responses.ImageQuickReply etc.
 
 The most common response is text:
 
@@ -131,8 +138,10 @@ Images just need a url. These also show up in the "Shared Photos" rail.
 
     new Image('https://i.imgur.com/ehSTCkO.gif')
 
-There are a few others that are supported too:
+The full list:
 
+* `new Text('Hello World')`
+* `new Image('https://i.imgur.com/ehSTCkO.gif')`
 * `new Generic(elements[])`
   https://developers.facebook.com/docs/messenger-platform/send-api-reference/generic-template
 * `new ImageQuickReply('https://i.imgur.com/ehSTCkO.gif', quickReplies[])` NOTE: the syntax for quick replies may change in the future since it's orthogonal to `Text` and `Image`.

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "express-handlebars": "^3.0.0",
     "request": "^2.81.0",
     "request-promise": "^4.2.0",
-    "url-join": "^1.1.0",
+    "url-join": "^2.0.1",
     "winston": "^2.3.1",
     "winston-slack-transport": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "express": "^4.14.1",
     "express-handlebars": "^3.0.0",
     "request": "^2.81.0",
-    "request-promise": "^4.1.1",
+    "request-promise": "^4.2.0",
     "url-join": "^1.1.0",
     "winston": "^2.3.1",
     "winston-slack-transport": "^2.0.0"
@@ -47,11 +47,11 @@
     "@condenast/eslint-config-condenast": "^0.9.1",
     "chai": "^3.5.0",
     "chai-http": "^3.0.0",
-    "eslint": "^3.15.0",
+    "eslint": "^3.18.0",
     "eslint-plugin-import": "^2.2.0",
-    "flow-bin": "^0.41.0",
+    "flow-bin": "^0.42.0",
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0",
-    "sinon": "^2.0.0"
+    "sinon": "^2.1.0"
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -218,9 +218,11 @@ class Messenger extends EventEmitter {
       pageAccessToken = config.get('messenger.pageAccessToken');
     } else {
       pageAccessToken = this.pages[pageId];
-      if (!pageAccessToken) {
+      // eslint-disable-next-line eqeqeq
+      if (!pageAccessToken && pageId != config.get('facebook.pageId')) {
         throw new Error(`Tried accessing a profile for page ${pageId} but the page config is missing`);
       }
+      pageAccessToken = config.get('messenger.pageAccessToken');
     }
     const options = {
       json: true,
@@ -360,7 +362,8 @@ class Messenger extends EventEmitter {
       pageAccessToken = config.get('messenger.pageAccessToken');
     } else {
       pageAccessToken = this.pages[pageId];
-      if (!pageAccessToken) {
+      // eslint-disable-next-line eqeqeq
+      if (!pageAccessToken && pageId != config.get('facebook.pageId')) {
         throw new Error(`Tried accessing a profile for page ${pageId} but the page config is missing`);
       }
     }

--- a/src/app.js
+++ b/src/app.js
@@ -33,12 +33,14 @@ class Messenger extends EventEmitter {
   /*:: greetings: RegExp */
   /*:: help: RegExp */
   /*:: options: Object */
+  /*:: pages: Object */
   constructor({
       hookPath = '/webhook',
       linkPath = '/link',
       // $FlowFixMe Flow isn't picking up RegEx|boolean right
-      emitGreetings = true
-    }/*: {hookPath: string, linkPath: string, emitGreetings: RegExp|boolean} */ = {}) {
+      emitGreetings = true,
+      pages = {}
+    }/*: {hookPath: string, linkPath: string, emitGreetings: RegExp|boolean, pages: Object} */ = {}) {
     super();
 
     this.conversationLogger = new ConversationLogger(config);
@@ -54,6 +56,8 @@ class Messenger extends EventEmitter {
       linkPath,
       emitGreetings: !!emitGreetings
     };
+
+    this.pages = pages;
 
     this.app = express();
     this.app.engine('handlebars', exphbs({defaultLayout: 'main'}));

--- a/src/app.js
+++ b/src/app.js
@@ -33,22 +33,27 @@ class Messenger extends EventEmitter {
   /*:: greetings: RegExp */
   /*:: help: RegExp */
   /*:: options: Object */
-  constructor({hookPath = '/webhook', linkPath = '/link', emitGreetings = true} = {}) {
+  constructor({
+      hookPath = '/webhook',
+      linkPath = '/link',
+      // $FlowFixMe Flow isn't picking up RegEx|boolean right
+      emitGreetings = true
+    }/*: {hookPath: string, linkPath: string, emitGreetings: RegExp|boolean} */ = {}) {
     super();
 
     this.conversationLogger = new ConversationLogger(config);
-
-    this.options = {
-      hookPath,
-      linkPath
-    };
 
     if (emitGreetings instanceof RegExp) {
       this.greetings = emitGreetings;
     } else {
       this.greetings = DEFAULT_GREETINGS_REGEX;
     }
-    this.options.emitGreetings = !!emitGreetings;
+
+    this.options = {
+      hookPath,
+      linkPath,
+      emitGreetings: !!emitGreetings
+    };
 
     this.app = express();
     this.app.engine('handlebars', exphbs({defaultLayout: 'main'}));

--- a/src/app.js
+++ b/src/app.js
@@ -342,10 +342,20 @@ class Messenger extends EventEmitter {
     return cache.set(session._key, session);
   }
 
-  send(recipientId/*: number */, messageData/*: Object */) {
+  send(recipientId/*: string|number */, messageData/*: Object */, pageId/*: string|void */) {
+    let pageAccessToken;
+    if (!pageId) {
+      // This will be deprecated in the future in favor of finding the token from `this.pages`
+      pageAccessToken = config.get('messenger.pageAccessToken');
+    } else {
+      pageAccessToken = this.pages[pageId];
+      if (!pageAccessToken) {
+        throw new Error(`Tried accessing a profile for page ${pageId} but the page config is missing`);
+      }
+    }
     const options = {
       uri: 'https://graph.facebook.com/v2.8/me/messages',
-      qs: { access_token: config.get('messenger.pageAccessToken') },
+      qs: { access_token: pageAccessToken },
       json: {
         dashbotTemplateId: 'right',
         recipient: {

--- a/src/app.js
+++ b/src/app.js
@@ -142,7 +142,7 @@ class Messenger extends EventEmitter {
           return session;
         }
 
-        return this.getPublicProfile(messagingEvent.sender.id)
+        return this.getPublicProfile(messagingEvent.sender.id, pageId)
           .then((profile) => {
             session.profile = profile;
             return session;
@@ -206,11 +206,15 @@ class Messenger extends EventEmitter {
     this.send(senderId, messageData);
   }
 
-  getPublicProfile(senderId/*: number */)/*: Promise<Object> */ {
+  getPublicProfile(senderId/*: number */, pageId/*: string */)/*: Promise<Object> */ {
+    const pageAccessToken = this.pages[pageId];
+    if (!pageAccessToken) {
+      throw new Error(`Tried accessing a profile for page ${pageId} but the page config is missing`);
+    }
     const options = {
       json: true,
       qs: {
-        access_token: config.get('messenger.pageAccessToken'),
+        access_token: pageAccessToken,
         fields: 'first_name,last_name,profile_pic,locale,timezone,gender'
       },
       url: `https://graph.facebook.com/v2.6/${senderId}`

--- a/src/app.js
+++ b/src/app.js
@@ -181,12 +181,11 @@ class Messenger extends EventEmitter {
       .then((session) => this.saveSession(session));
   }
 
-  // FIXME this needs pageId update too
-  doLogin(senderId/*: number */) {
+  doLogin(senderId/*: number */, pageId/*: string */) {
     // Open question: is building the event object worth it for the 'emit'?
     const event = {
       sender: {id: senderId},
-      recipient: {id: config.get('facebook.pageId')},
+      recipient: {id: pageId},
       timestamp: new Date().getTime()
     };
     this.emit('login', {event, senderId});

--- a/src/app.js
+++ b/src/app.js
@@ -181,6 +181,7 @@ class Messenger extends EventEmitter {
       .then((session) => this.saveSession(session));
   }
 
+  // FIXME this needs pageId update too
   doLogin(senderId/*: number */) {
     // Open question: is building the event object worth it for the 'emit'?
     const event = {
@@ -211,10 +212,16 @@ class Messenger extends EventEmitter {
     this.send(senderId, messageData);
   }
 
-  getPublicProfile(senderId/*: number */, pageId/*: string */)/*: Promise<Object> */ {
-    const pageAccessToken = this.pages[pageId];
-    if (!pageAccessToken) {
-      throw new Error(`Tried accessing a profile for page ${pageId} but the page config is missing`);
+  getPublicProfile(senderId/*: number */, pageId/*: string|void */)/*: Promise<Object> */ {
+    let pageAccessToken;
+    if (!pageId) {
+      // This will be deprecated in the future in favor of finding the token from `this.pages`
+      pageAccessToken = config.get('messenger.pageAccessToken');
+    } else {
+      pageAccessToken = this.pages[pageId];
+      if (!pageAccessToken) {
+        throw new Error(`Tried accessing a profile for page ${pageId} but the page config is missing`);
+      }
     }
     const options = {
       json: true,
@@ -347,7 +354,7 @@ class Messenger extends EventEmitter {
     return this.cache.set(session._key, session);
   }
 
-  send(recipientId/*: string|number */, messageData/*: Object */, pageId/*: string|void */) {
+  send(recipientId/*: string|number */, messageData/*: Object */, pageId/*: string|void */)/* Promise<Object> */ {
     let pageAccessToken;
     if (!pageId) {
       // This will be deprecated in the future in favor of finding the token from `this.pages`

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -80,7 +80,7 @@ describe('app', () => {
     });
 
     it('gets public profile with missing page configuration with deprecated config', () => {
-      return messenger.getPublicProfile(12345, 1029384756)
+      return messenger.getPublicProfile(12345, 1029384756)  // from example.env
         .then((profile) => {
           assert.ok(profile);
         });
@@ -402,7 +402,7 @@ describe('app', () => {
     });
 
     it('passes sender id and message with deprecated config', () => {
-      return messenger.send('senderId', {foo: 'bar'}, 1029384756)
+      return messenger.send('senderId', {foo: 'bar'}, 1029384756)  // from example.env
         .then(() => {
           assert.equal(reqPromise.post.args[0][0].json.recipient.id, 'senderId');
           assert.deepEqual(reqPromise.post.args[0][0].json.message, {foo: 'bar'});

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -78,6 +78,13 @@ describe('app', () => {
         assert.equal(err.message.substr(0, 15), 'Tried accessing');
       }
     });
+
+    it('gets public profile with missing page configuration with deprecated config', () => {
+      return messenger.getPublicProfile(12345, 1029384756)
+        .then((profile) => {
+          assert.ok(profile);
+        });
+    });
   });
 
   describe('onAuth', function () {
@@ -388,6 +395,14 @@ describe('app', () => {
 
     it('passes sender id and message with deprecated arguments', () => {
       return messenger.send('senderId', {foo: 'bar'})
+        .then(() => {
+          assert.equal(reqPromise.post.args[0][0].json.recipient.id, 'senderId');
+          assert.deepEqual(reqPromise.post.args[0][0].json.message, {foo: 'bar'});
+        });
+    });
+
+    it('passes sender id and message with deprecated config', () => {
+      return messenger.send('senderId', {foo: 'bar'}, 1029384756)
         .then(() => {
           assert.equal(reqPromise.post.args[0][0].json.recipient.id, 'senderId');
           assert.deepEqual(reqPromise.post.args[0][0].json.message, {foo: 'bar'});

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -55,6 +55,21 @@ describe('app', () => {
   });
 
   describe('getPublicProfile', () => {
+    it('gets public profile with deprecated arguments', () => {
+      return messenger.getPublicProfile(12345)
+        .then((profile) => {
+          assert.ok(profile);
+        });
+    });
+
+    it('gets public profile', () => {
+      const myMessenger = new Messenger({pages: {1337: '1337accesstoken'}});
+      return myMessenger.getPublicProfile(12345, 1337)
+        .then((profile) => {
+          assert.ok(profile);
+        });
+    });
+
     it('throws if messenger is missing page configuration', () => {
       try {
         messenger.getPublicProfile(12345, 1337);
@@ -361,7 +376,7 @@ describe('app', () => {
       }
     });
 
-    it('passes sender id and message with deprecated arguments', () => {
+    it('passes sender id and message', () => {
       const myMessenger = new Messenger({pages: {1337: '1337accesstoken'}});
       return myMessenger.send('senderId', {foo: 'bar'}, 1337)
         .then(() => {

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -54,6 +54,17 @@ describe('app', () => {
     });
   });
 
+  describe('getPublicProfile', () => {
+    it('throws if messenger is missing page configuration', () => {
+      try {
+        messenger.getPublicProfile(12345, 1337);
+        assert.ok(false, 'This path should not execute');
+      } catch (err) {
+        assert.equal(err.message.substr(0, 15), 'Tried accessing');
+      }
+    });
+  });
+
   describe('onAuth', function () {
     this.timeout(100);
     const baseEvent = {


### PR DESCRIPTION
## Why are we doing this?

Currently, the SDK assumes that the bot will only be deployed on one page. But Facebook lets you  associate a bot with multiple pages. This PR adds the plumbing necessary so calls that depend on the page now take `pageId` as an argument. The SDK constructor has a new option for page ids because it needs to know how to turn a page id into an access token. For now, the new `pageId` is optional as long as the user still has the existing page id and page access token config set.

* getPublicProfile can work for multiple pages
* send can work for multiple pages
* configuration is split better between config needed bot config for listening (app) and config for responding (page).

Closes #30 

## Did you document your work?

* It turns out a lot of the API wasn't really documented, so this adds documentation using the current format with warnings about future `pageId` changes

## How can someone test these changes?

Steps to manually verify the change:

1. `npm i`
2. `npm t`

Link to an existing bot and make sure your existing bot works:
1. `npm link`
2. go to your bot
3. `npm link launch-vehicle-fbm`
4. run and test your bot

## What possible risks or adverse effects are there?

* The way the page config is possibly up in the air. Right now it's a simple mapping of page ids to access tokens, but maybe we'll want it to be richer in the future. Since I can't think of a use case, I think it's fine to go with the simple solution and make another breaking change later.

## What are the follow-up tasks?

* Actually sending is a pain because to take advantage of the new code, you have to explicitly pass in the page id. Implement the solution based on https://github.com/CondeNast/launch-vehicle-fbm/issues/30#issuecomment-283773917

## Are there any known issues?

none

## Did the test coverage decrease?

increases. Some previously uncovered code is now covered. Most of the new LOC is tests, then backwards compatibility that can be deleted later.