### PR TITLE
Add 'app.starting' and 'app.started' events

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ The event name and what's in the `data` for each event handler:
   * `senderId` The ID of the sender
   * `payload` Direct access to `event.postback.payload`
 
+#### Other Events
+* `app.starting` signal that the `Messenger.start` has been called and the application is in the process of coming online
+* `app.started` signal that the SDK's Express server is now listening on the specified `port` and ready for requests
 * `finish` (optional) Signal that you're done processing. This is mostly useful
   for your tests when you have Promise chains. The SDK currently does nothing
   with this event.

--- a/src/app.js
+++ b/src/app.js
@@ -159,7 +159,8 @@ class Messenger extends EventEmitter {
     this.app.listen(port, (err) => {
       if (err) throw err;
       this.emit('app.started', {port});
-      // TODO console.log(`Set your webhook to: `)
+      debug('Server running on port %s', port);
+     // TODO console.log(`Set your webhook to: `)
     });
   }
 

--- a/src/app.js
+++ b/src/app.js
@@ -155,9 +155,10 @@ class Messenger extends EventEmitter {
 
   start() {
     const port = config.get('port');
+    this.emit('app.starting', {port});
     this.app.listen(port, (err) => {
       if (err) throw err;
-      debug('Server running on port %s', port);
+      this.emit('app.started', {port});
       // TODO console.log(`Set your webhook to: `)
     });
   }

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -123,6 +123,25 @@ describe('app', () => {
     });
   });
 
+  describe('start', () => {
+    beforeEach(() => {
+      sinon.stub(messenger.app, 'listen');
+    });
+
+    afterEach(() => {
+      messenger.app.listen.restore();
+    });
+
+    it('emits a "starting" event', (done) => {
+      messenger.once('app.starting', (payload) => {
+        assert.ok(payload.port);
+        done();
+      });
+
+      messenger.start();
+    });
+  });
+
   describe('doLogin', function () {
     this.timeout(100);
     it('emits login event', () => {


### PR DESCRIPTION
## Why are we doing this?

Following the discussion on #54, it was determined that there is value in adding events related to the application starting up. This PR adds `app.starting` and `app.started` to communicate status from the SDK to the application.

## Did you document your work?

Yes, the `README` has been updated with information on the new events.

## How can someone test these changes?

`npm i`
`npm t`

Optionally, start up a test bot that responds to these events. Some sample code to use:

```javascript
messenger.on('app.starting', ({port}) => {
  console.log(`The launch vehicle boosters are firing on port ${port}; getting ready for launch...`);
});

messenger.on('app.started', ({port}) => {
  console.log(`Lift off! The launch vehicle is now listening for requests on port ${port}`);
});
```

## What possible risks or adverse effects are there?

These events are informational and no adverse effects have been identified.

## What are the follow-up tasks?

Decide if we want to close #15 and leave `start` as is (refer to the discussion on #54 also).

## Are there any known issues?

None identified.

## Did the test coverage decrease?

The `app.starting` is covered but `app.started` event is not.