### PR TITLE
Log the webhook to ease first time setup

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -159,8 +159,7 @@ class Messenger extends EventEmitter {
     this.app.listen(port, (err) => {
       if (err) throw err;
       this.emit('app.started', {port});
-      debug('Server running on port %s', port);
-     // TODO console.log(`Set your webhook to: `)
+      debug('Server running on: http://localhost:%s Set your webhook to: %s', port, urlJoin(config.get('serverUrl'), this.options.hookPath));
     });
   }
 


### PR DESCRIPTION
## Why are we doing this?

This implements a very old TODO. When starting the server, you get a logging statement when it's up to give you feedback on what port it's running on so you can test it out. This improves that feedback with a url. Based on a guessed host of `localhost`. We could probably dig in and find a more accurate host name, but if they're running in Docker, the hostname we grab won't work anyways. Users can now option-click on the url to test the webhook. It also logs the webhook url. If the user is setting up the Facebook app settings, they'll know what url to put.

It's one log line instead of two because I see this as one event. And I believe in 1 event == 1 log line.

## Did you document your work?

N/A

## How can someone test these changes?

Steps to manually verify the change:

1. `npm link` here
2. `npm link launch-vehicle-fbm` in an existing bot
3. When you start your bot with `DEBUG messenger*`, you'll see something like:
```
  messenger Server running on: http://localhost:3000 Set your webhook to: https://whatever.your.serverurl.is/webhook +762ms
```

## What possible risks or adverse effects are there?

* the output might lie. It should be rare and only in exotic environments where everything is a lie anyways (docker comes to mind)

## What are the follow-up tasks?

* none

## Are there any known issues?

none

## Did the test coverage decrease?

N/A