### PR TITLE
Sandbox the tests: move from `sinon.stub` to `sandbox`

### DIFF
--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -12,6 +12,7 @@ chai.use(chaiHttp);
 
 describe('app', () => {
   let messenger;
+  let sandbox;
   let session;
 
   before(() => {
@@ -19,7 +20,9 @@ describe('app', () => {
   });
 
   beforeEach(() => {
-    sinon.stub(messenger, 'pageSend').resolves({});
+    sandbox = sinon.sandbox.create();
+    sandbox.stub(messenger, 'pageSend').resolves({});
+    sandbox.stub(messenger.app, 'listen');
     session = {
       profile: {
         first_name: '  Guy  ',
@@ -30,7 +33,7 @@ describe('app', () => {
 
   afterEach(() => {
     // TODO investigate making the suite mock `reqPromise.post` instead of `send`
-    messenger.pageSend.restore && messenger.pageSend.restore();
+    sandbox.restore();
   });
 
   describe('Response', () => {
@@ -124,14 +127,6 @@ describe('app', () => {
   });
 
   describe('start', () => {
-    beforeEach(() => {
-      sinon.stub(messenger.app, 'listen');
-    });
-
-    afterEach(() => {
-      messenger.app.listen.restore();
-    });
-
     it('emits a "starting" event', (done) => {
       messenger.once('app.starting', (payload) => {
         assert.ok(payload.port);
@@ -536,15 +531,9 @@ describe('app', () => {
   });
 
   describe('send', function () {
-    let postStub;
-
     beforeEach(() => {
       messenger.pageSend.restore();
-      postStub = sinon.stub(reqPromise, 'post').resolves({});
-    });
-
-    afterEach(() => {
-      postStub.restore();
+      sandbox.stub(reqPromise, 'post').resolves({});
     });
 
     it('throws if messenger is missing page configuration', () => {

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -15,11 +15,8 @@ describe('app', () => {
   let sandbox;
   let session;
 
-  before(() => {
-    messenger = new Messenger();
-  });
-
   beforeEach(() => {
+    messenger = new Messenger();
     sandbox = sinon.sandbox.create();
     sandbox.stub(messenger, 'pageSend').resolves({});
     sandbox.stub(messenger.app, 'listen');
@@ -383,7 +380,7 @@ describe('app', () => {
 
     it('emits "greeting" event when provided a pattern', () => {
       const myMessenger = new Messenger({emitGreetings: /^olleh/i});
-      sinon.stub(myMessenger, 'send');
+      sandbox.stub(myMessenger, 'send');
 
       const text = "olleh, it's just olleh, backwards";
       const event = Object.assign({}, baseEvent, { message: { text: text } });
@@ -401,7 +398,7 @@ describe('app', () => {
 
     it('emits "text" event for greeting when emitGreetings is disabled', () => {
       const myMessenger = new Messenger({emitGreetings: false});
-      sinon.stub(myMessenger, 'send');
+      sandbox.stub(myMessenger, 'send');
 
       const text = "hello, is it me you're looking for?";
       const event = Object.assign({}, baseEvent, {
@@ -621,11 +618,7 @@ describe('app', () => {
 
     beforeEach(() => {
       messenger = new Messenger({cache: new Cacheman('test')});
-      sinon.stub(messenger, 'getPublicProfile').resolves({});
-    });
-
-    afterEach(() => {
-      messenger.getPublicProfile.restore();
+      sandbox.stub(messenger, 'getPublicProfile').resolves({});
     });
 
     it('uses default session if cache returns falsey', () => {
@@ -638,7 +631,6 @@ describe('app', () => {
         }
       };
       messenger = new Messenger({cache: nullCache});
-      sinon.stub(messenger, 'getPublicProfile').resolves({});
 
       return messenger.routeEachMessage(baseMessage)
         .then((session) => {

--- a/test/conversationLogger.spec.js
+++ b/test/conversationLogger.spec.js
@@ -5,15 +5,17 @@ const { ConversationLogger } = require('../src/conversationLogger');
 const config = require('config').get('launch-vehicle-fbm');
 
 describe('conversationLogger', () => {
+  let sandbox;
   const conversationLogger = new ConversationLogger(config);
   const logger = conversationLogger.logger;  // shorter alias
 
   beforeEach(() => {
-    sinon.stub(logger, 'info');
+    sandbox = sinon.sandbox.create();
+    sandbox.stub(logger, 'info');
   });
 
   afterEach(() => {
-    logger.info.restore();
+    sandbox.restore();
   });
 
   describe('logIncoming', () => {

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -2,7 +2,6 @@ const assert = require('assert');
 
 const main = require('..');
 
-
 describe('main', () => {
   it('publicly exposes things', () => {
     assert.equal(typeof main.Messenger, 'function');

--- a/test/responses.spec.js
+++ b/test/responses.spec.js
@@ -10,13 +10,16 @@ const Text = responses.Text;
 
 describe('Responses', () => {
   let originalDictionary;
+  let sandbox;
 
-  before(() => {
+  beforeEach(() => {
     originalDictionary = responses._dictionary;
+    sandbox = sinon.sandbox.create();
   });
 
-  after(() => {
+  afterEach(() => {
     responses._dictionary = originalDictionary;
+    sandbox.restore();
   });
 
   describe('dictionary', () => {
@@ -27,7 +30,7 @@ describe('Responses', () => {
     it('loads a dictionary', () => {
       const responsesRef = Object.keys(require.cache).find((x) => x.endsWith('/src/responses.js'));
       delete require.cache[responsesRef];
-      sinon.stub(appRootDir, 'get').returns(path.resolve(path.join(__dirname, './fixtures')));
+      sandbox.stub(appRootDir, 'get').returns(path.resolve(path.join(__dirname, './fixtures')));
 
       const dictionary = require('../src/responses')._dictionary;
 


### PR DESCRIPTION
## Why are we doing this?

Using `sandbox` rather than `sinon` simplifies the `afterEach` and is also common to our application practices at Condé Nast. Simplifying this small part of the testing setup and teardown process also likely encourages more tests!

Credit to @tswicegood for pointing this out [in a comment] on #56 

closes #57

[in a comment]: https://github.com/CondeNast/launch-vehicle-fbm/pull/56/files#r112085008

## Did you document your work?

N/A - testing changes only and tests themselves aren't impacted, just the setup and teardown.

## How can someone test these changes?

`npm i`
`npm t`
🎉 

## What possible risks or adverse effects are there?

None identified.

## What are the follow-up tasks?

None identified.

## Are there any known issues?

Moving a few things from `before` to `beforeEach` could result in a small latency hit but nothing that should be terrible.

## Did the test coverage decrease?

Nope!