### PR TITLE
Limit `verifyRequestSignature` calls on `application/json` POSTs to the Messenger webhook route

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -433,6 +433,7 @@ class Messenger extends EventEmitter {
 
     const [method, signatureHash] = signature.split('=');
     // TODO assert method === 'sha1'
+
     const expectedHash = crypto.createHmac(method, config.get('messenger.appSecret')).update(buf).digest('hex');
     if (signatureHash !== expectedHash) {
       throw new Error(`Couldn't validate the request signature: ${config.get('messenger.appSecret')}`);

--- a/src/app.js
+++ b/src/app.js
@@ -96,7 +96,6 @@ class Messenger extends EventEmitter {
     this.app.engine('handlebars', exphbs({defaultLayout: 'main'}));
     this.app.set('view engine', 'handlebars');
 
-    this.app.use(bodyParser.json({ verify: this.verifyRequestSignature.bind(this) }));
     this.app.use(bodyParser.urlencoded({ extended: true }));
     this.app.use(express.static('public'));
 
@@ -114,7 +113,7 @@ class Messenger extends EventEmitter {
       }
     });
 
-    this.app.post(hookPath, (req, res) => {
+    this.app.post(hookPath, bodyParser.json({ verify: this.verifyRequestSignature.bind(this) }), (req, res) => {
       const data = req.body;
       this.conversationLogger.logIncoming(data);
       // `data` reference:
@@ -435,7 +434,6 @@ class Messenger extends EventEmitter {
     const [method, signatureHash] = signature.split('=');
     // TODO assert method === 'sha1'
     const expectedHash = crypto.createHmac(method, config.get('messenger.appSecret')).update(buf).digest('hex');
-
     if (signatureHash !== expectedHash) {
       throw new Error(`Couldn't validate the request signature: ${config.get('messenger.appSecret')}`);
     }

--- a/src/app.js
+++ b/src/app.js
@@ -433,8 +433,8 @@ class Messenger extends EventEmitter {
 
     const [method, signatureHash] = signature.split('=');
     // TODO assert method === 'sha1'
-
     const expectedHash = crypto.createHmac(method, config.get('messenger.appSecret')).update(buf).digest('hex');
+
     if (signatureHash !== expectedHash) {
       throw new Error(`Couldn't validate the request signature: ${config.get('messenger.appSecret')}`);
     }

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -20,6 +20,7 @@ describe('app', () => {
     sandbox = sinon.sandbox.create();
     sandbox.stub(messenger, 'pageSend').resolves({});
     sandbox.stub(messenger.app, 'listen');
+    sandbox.stub(messenger, 'verifyRequestSignature');
     session = {
       profile: {
         first_name: '  Guy  ',
@@ -604,6 +605,27 @@ describe('app', () => {
         .get('/ping')
         .end(function (err, res) {
           assert.equal(res.statusCode, 200);
+          done();
+        });
+    });
+
+    it('provides a route for Facebook Messenger validation', (done) => {
+      const verifyToken = config.get('messenger.validationToken');
+      chai.request(messenger.app)
+        .get(messenger.options.hookPath)
+        .query({'hub.mode': 'subscribe', 'hub.verify_token': verifyToken})
+        .end(function (err, res) {
+          assert.equal(res.statusCode, 200);
+          done();
+        });
+    });
+
+    it('provides Facebook Messenger validation that rejects bad verify token', (done) => {
+      chai.request(messenger.app)
+        .get(messenger.options.hookPath)
+        .query({'hub.mode': 'subscribe', 'hub.verify_token': 'bad token'})
+        .end(function (err, res) {
+          assert.equal(res.statusCode, 403);
           done();
         });
     });

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -20,7 +20,6 @@ describe('app', () => {
     sandbox = sinon.sandbox.create();
     sandbox.stub(messenger, 'pageSend').resolves({});
     sandbox.stub(messenger.app, 'listen');
-    sandbox.stub(messenger, 'verifyRequestSignature');
     session = {
       profile: {
         first_name: '  Guy  ',
@@ -630,6 +629,48 @@ describe('app', () => {
         });
     });
 
+    it('provides a webhook that calls verifyRequestSignature when JSON is posted', (done) => {
+      sandbox.spy(Messenger.prototype, 'verifyRequestSignature');
+      const messenger = new Messenger();
+      sandbox.stub(messenger.conversationLogger, 'logIncoming');
+      sandbox.stub(messenger, 'routeEachMessage');
+      const message = {
+        object: 'page',
+        entry: [
+          {
+            id: '248424725280875',
+            time: 1493394449330
+          }
+        ]
+      };
+
+      chai.request(messenger.app)
+        .post(messenger.options.hookPath)
+        .set('content-type', 'application/json')
+        .set('x-hub-signature', 'sha1=54060dfbdd35f0fd636c12953ab2b7feffd9a47f')
+        .send(message)
+        .end(function (err, res) {
+          assert.equal(Messenger.prototype.verifyRequestSignature.callCount, 1);
+          done();
+        });
+    });
+
+    it('allows other routes that skip verifyRequestSignature when JSON is posted', (done) => {
+      sandbox.spy(Messenger.prototype, 'verifyRequestSignature');
+      const messenger = new Messenger();
+      messenger.app.post('/testing', (req, res) => {
+        res.send('💥');
+      });
+
+      chai.request(messenger.app)
+        .post('/testing')
+        .set('content-type', 'application/json')
+        .end(function (err, res) {
+          assert.equal(Messenger.prototype.verifyRequestSignature.callCount, 0);
+          assert.equal(res.statusCode, 200);
+          done();
+        });
+    });
   });
 
   describe('routeEachMessage session', () => {


### PR DESCRIPTION
## Why are we doing this?

This PR limits calling `verifyRequestSignature` to `POST` routes with the`application/json` header to only the route defined by `messenger.options.webhook`. The `verifyRequestSignature` function performs a validation that is specific to Facebook Messenger and calling this on any `POST` with the `application/json` header was effectively blocking application developers from adding other routes to the Express server instance in `messenger`.

docs for the handler: http://expressjs.com/en/4x/api.html#app.METHOD

Closes #61 

## Did you document your work?

No `README` updates as these changes ars all under the hood. Also, the argument can be made that this should have been the expected behavior instead of what is currently implemented.

## How can someone test these changes?

`npm i`
`npm t`

Optionally, create and run a test bot that has an added `POST` route. Manually that `POST` route with something like [Postman].

A simple example to add to an existing test bot:
```
messenger.app.post(`/testing`, (req, res) => {
  res.send('💥');
});
```

What this looks like manually tested with Postman:
![screen shot 2017-04-28 at 12 12 43 pm](https://cloud.githubusercontent.com/assets/1305168/25539272/086e5234-2c0c-11e7-9383-3824a6fdfbfe.png)

[Postman]: https://www.getpostman.com/

## What possible risks or adverse effects are there?

None identified.

## What are the follow-up tasks?

* Ditch `chai-http`?
* Release a new minor version with this change.

## Are there any known issues?

None identified.

## Did the test coverage decrease?

Increased; added tests to cover `POST` to `webhook`, `POST` to a _test_ route, and some additional tests around `GET` on the `webhook`. The `GET` tests are not directly related to the changes in this diff, but add coverage on the Facebook webhook validation.