### PR TITLE
Add "pause" webhook to allow for live person takeovers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ messenger.start();  // Start listening
 
 * `cache` (default: [cacheman] memory cache) See [Session cache](#session-cache)
 * `hookPath` (default: `/webhook`)
-* `linkPath` (default: `/link`)
 * `pages`: A map of page ids to page access tokens `{1029384756: 'ThatsAReallyLongStringYouGotThere'}`. Currently optional but config will migrate to this in the future
 * `port` (default: `3000`)
 * `emitGreetings` (default: true)
@@ -35,6 +34,10 @@ messenger.start();  // Start listening
 
 Additional options are set via environment variables. See `example.env` for an
 example.
+
+### Endpoints
+* `/webhook` (override with `options.hookPath`) -- The Messenger [webbhook](https://developers.facebook.com/docs/graph-api/webhooks)
+* `/pause` -- Dashbot compatible pause for live person takeovers. See [Dashbot's docs](https://www.dashbot.io/sdk/pause) for usage. Currently, pauses only last for 12 hours in case the operator forgets to unpause
 
 ### Responding to events
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1252,7 +1252,8 @@
     },
     "extend": {
       "version": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-      "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ="
+      "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+      "dev": true
     },
     "external-editor": {
       "version": "2.0.5",
@@ -2621,15 +2622,15 @@
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "request": {
-      "version": "2.82.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.82.0.tgz",
-      "integrity": "sha512-/QWqfmyTfQ4OYs6EhB1h2wQsX9ZxbuNePCvCm0Mdz/mxw73mjdg0D4QdIl0TQBFs35CZmMXLjk0iCGK395CUDg==",
+      "version": "2.83.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
       "requires": {
         "aws-sign2": "0.7.0",
         "aws4": "1.6.0",
         "caseless": "0.12.0",
         "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-        "extend": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+        "extend": "3.0.1",
         "forever-agent": "0.6.1",
         "form-data": "2.3.1",
         "har-validator": "5.0.3",
@@ -2638,10 +2639,10 @@
         "is-typedarray": "1.0.0",
         "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
         "json-stringify-safe": "5.0.1",
-        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+        "mime-types": "2.1.17",
         "oauth-sign": "0.8.2",
         "performance-now": "2.1.0",
-        "qs": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+        "qs": "6.5.1",
         "safe-buffer": "5.1.1",
         "stringstream": "0.0.5",
         "tough-cookie": "2.3.3",
@@ -2649,6 +2650,29 @@
         "uuid": "3.1.0"
       },
       "dependencies": {
+        "extend": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+        },
+        "mime-db": {
+          "version": "1.30.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+          "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+        },
+        "mime-types": {
+          "version": "2.1.17",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+          "requires": {
+            "mime-db": "1.30.0"
+          }
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+        },
         "uuid": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
@@ -3319,7 +3343,7 @@
       "version": "https://registry.npmjs.org/winston-slack-transport/-/winston-slack-transport-2.0.0.tgz",
       "integrity": "sha1-hWk8hb5P6Uc9SKvWGWrLfljgZaU=",
       "requires": {
-        "request": "2.82.0"
+        "request": "2.83.0"
       }
     },
     "wordwrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -321,32 +321,6 @@
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
     },
-    "build": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/build/-/build-0.1.4.tgz",
-      "integrity": "sha1-cH/gJv/O3crL/c3zVur9pk8VEEY=",
-      "dev": true,
-      "requires": {
-        "cssmin": "0.3.2",
-        "jsmin": "1.0.1",
-        "jxLoader": "0.1.1",
-        "moo-server": "1.3.0",
-        "promised-io": "0.3.5",
-        "timespan": "2.3.0",
-        "uglify-js": "1.3.5",
-        "walker": "1.0.7",
-        "winston": "https://registry.npmjs.org/winston/-/winston-2.3.1.tgz",
-        "wrench": "1.3.9"
-      },
-      "dependencies": {
-        "uglify-js": {
-          "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.3.5.tgz",
-          "integrity": "sha1-S1v/+Rhu/7qoiOTJ6UvZ/EyUkp0=",
-          "dev": true
-        }
-      }
-    },
     "builtin-modules": {
       "version": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
@@ -683,12 +657,6 @@
         }
       }
     },
-    "cssmin": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/cssmin/-/cssmin-0.3.2.tgz",
-      "integrity": "sha1-3c5MVHtRCuDVlKjx+/iq+OLFwA0=",
-      "dev": true
-    },
     "cycle": {
       "version": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
       "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
@@ -722,11 +690,18 @@
       }
     },
     "debug": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.0.1.tgz",
-      "integrity": "sha512-6nVc6S36qbt/mutyt+UGMnawAMrPDZUPQjRZI3FS9tCtDRhvxJbK79unYBLPi+z5SLXQ3ftoVBFCblQtNSls8w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "requires": {
-        "ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+        "ms": "2.0.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "decamelize": {
@@ -950,7 +925,7 @@
         "chalk": "2.1.0",
         "concat-stream": "1.6.0",
         "cross-spawn": "5.1.0",
-        "debug": "3.0.1",
+        "debug": "3.1.0",
         "doctrine": "2.0.0",
         "eslint-scope": "3.7.1",
         "espree": "3.5.1",
@@ -1881,12 +1856,6 @@
       "integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A==",
       "dev": true
     },
-    "jsmin": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/jsmin/-/jsmin-1.0.1.tgz",
-      "integrity": "sha1-570NzWSWw79IYyNb9GGj2YqjuYw=",
-      "dev": true
-    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -1942,26 +1911,6 @@
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.22.tgz",
       "integrity": "sha1-MzCvdWyralQnAMZLLk5KoGLVL/8=",
       "dev": true
-    },
-    "jxLoader": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jxLoader/-/jxLoader-0.1.1.tgz",
-      "integrity": "sha1-ATTqUUTlM7WU/B/yX/GU4jXFPs0=",
-      "dev": true,
-      "requires": {
-        "js-yaml": "0.3.7",
-        "moo-server": "1.3.0",
-        "promised-io": "0.3.5",
-        "walker": "1.0.7"
-      },
-      "dependencies": {
-        "js-yaml": {
-          "version": "0.3.7",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-0.3.7.tgz",
-          "integrity": "sha1-1znY7oZGHlSzVNan19HyrZoWf2I=",
-          "dev": true
-        }
-      }
     },
     "kind-of": {
       "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
@@ -2130,15 +2079,6 @@
       "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
     },
-    "makeerror": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
-      "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
-      "dev": true,
-      "requires": {
-        "tmpl": "1.0.4"
-      }
-    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -2264,12 +2204,6 @@
           }
         }
       }
-    },
-    "moo-server": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/moo-server/-/moo-server-1.3.0.tgz",
-      "integrity": "sha1-XceVaVZaENbv7VQ5SR5p0jkuWPE=",
-      "dev": true
     },
     "ms": {
       "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
@@ -2590,12 +2524,6 @@
       "requires": {
         "asap": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz"
       }
-    },
-    "promised-io": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/promised-io/-/promised-io-0.3.5.tgz",
-      "integrity": "sha1-StIXuzZYvKrplGsXqGaOzYUeE1Y=",
-      "dev": true
     },
     "proxy-addr": {
       "version": "1.1.5",
@@ -2939,12 +2867,11 @@
       "dev": true
     },
     "sinon": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-3.3.0.tgz",
-      "integrity": "sha512-/flfGfIxIRXSvZBHJzIf3iAyGYkmMQq6SQjA0cx9SOuVuq+4ZPPO4LJtH1Ce0Lznax1KSG1U6Dad85wIcSW19w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.0.0.tgz",
+      "integrity": "sha1-pUpfAjeqHdIhXl6ByJtCtQxP22s=",
       "dev": true,
       "requires": {
-        "build": "0.1.4",
         "diff": "3.2.0",
         "formatio": "1.2.0",
         "lodash.get": "4.4.2",
@@ -3214,12 +3141,6 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
-    "timespan": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/timespan/-/timespan-2.3.0.tgz",
-      "integrity": "sha1-SQLOBAvRPYRcj1myfp1ZutbzmSk=",
-      "dev": true
-    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -3228,12 +3149,6 @@
       "requires": {
         "os-tmpdir": "1.0.2"
       }
-    },
-    "tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
-      "dev": true
     },
     "tough-cookie": {
       "version": "2.3.3",
@@ -3364,15 +3279,6 @@
         "extsprintf": "1.3.0"
       }
     },
-    "walker": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
-      "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
-      "dev": true,
-      "requires": {
-        "makeerror": "1.0.11"
-      }
-    },
     "whatwg-fetch": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
@@ -3423,12 +3329,6 @@
     "wrappy": {
       "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "wrench": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.3.9.tgz",
-      "integrity": "sha1-bxPsNRRTF+spLKX2UxORskQRFBE=",
-      "dev": true
     },
     "write": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "cacheman": "^2.2.1",
     "config": "^1.26.2",
     "dashbot": "^9.2.0",
-    "debug": "^3.0.1",
+    "debug": "^3.1.0",
     "express": "^4.15.5",
     "express-handlebars": "^3.0.0",
     "request": "^2.82.0",
@@ -53,6 +53,6 @@
     "flow-bin": "^0.55.0",
     "istanbul": "^0.4.5",
     "mocha": "^3.5.3",
-    "sinon": "^3.3.0"
+    "sinon": "^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "debug": "^3.1.0",
     "express": "^4.15.5",
     "express-handlebars": "^3.0.0",
-    "request": "^2.82.0",
+    "request": "^2.83.0",
     "request-promise": "^4.2.2",
     "url-join": "^2.0.2",
     "winston": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint --ignore-path .gitignore .",
     "pretest": "npm run lint",
-    "tdd": "NODE_ENV=test env $(cat test.env | xargs) mocha -R dot --recursive --watch",
+    "tdd": "NODE_ENV=test env $(cat test.env | xargs) mocha -R dot --recursive --watch --bail",
     "test": "NODE_ENV=test env $(cat test.env | xargs) istanbul cover _mocha -- --recursive"
   },
   "engines": {

--- a/src/app.js
+++ b/src/app.js
@@ -142,8 +142,12 @@ class Messenger extends EventEmitter {
     }));
 
     this.app.post('/pause', bodyParser.json(), (req, res) => {
-      const userId = req.body.userId;
-      const paused = req.body.paused;
+      const { userId, paused } = req.body;
+      if (!userId && paused === undefined) {
+        res.sendStatus(400);
+        return;
+      }
+
       // If we need to store more than `pausedUsers` in the future, use a
       // general purpose map so we only have to make one trip to Redis
       this.cache.get('pausedUsers')

--- a/src/app.js
+++ b/src/app.js
@@ -61,7 +61,6 @@ class Messenger extends EventEmitter {
   /*:: pages: Object */
   constructor({
     hookPath = '/webhook',
-    linkPath = '/link',
     emitGreetings = true,
     cache,
     pages = {}
@@ -78,8 +77,7 @@ class Messenger extends EventEmitter {
 
     this.options = {
       emitGreetings: !!emitGreetings,
-      hookPath,
-      linkPath
+      hookPath
     };
 
     if (cache) {
@@ -131,14 +129,11 @@ class Messenger extends EventEmitter {
       }
     });
 
-    this.app.post(linkPath, (req, res) => {
+    // Stub routes for future functionality
+    this.app.post('/link', (req, res) => {
       this.onLink(req.body);
       res.sendStatus(200);
     });
-
-    // App routes
-
-    // Stub routes for future functionality
     this.app.get('/login', (req, res) => res.render('login', {
       appId: config.get('facebook.appId'),
       serverUrl: config.get('serverUrl')

--- a/src/app.js
+++ b/src/app.js
@@ -16,7 +16,7 @@ const { ConversationLogger } = require('./conversationLogger');
 
 
 const SESSION_TIMEOUT_MS = 24 * 3600 * 1000; // 24 hours
-const PAUSE_TIMEOUT_MS = 1 * 3600 * 1000; // 1 hour
+const PAUSE_TIMEOUT_MS = 12 * 3600 * 1000; // 12 hours
 
 const DEFAULT_GREETINGS_REGEX = /^(get started|good(morning|afternoon)|hello|hey|hi|hola|what's up)/i;
 const DEFAULT_HELP_REGEX = /^help\b/i;

--- a/src/app.js
+++ b/src/app.js
@@ -21,8 +21,7 @@ const PAUSE_TIMEOUT_MS = 1 * 3600 * 1000; // 1 hour
 const DEFAULT_GREETINGS_REGEX = /^(get started|good(morning|afternoon)|hello|hey|hi|hola|what's up)/i;
 const DEFAULT_HELP_REGEX = /^help\b/i;
 
-/*::
-type Session = {_pageId: string|number, count: number, profile: ?Object} */
+/*:: type Session = {_pageId: string|number, count: number, profile: ?Object} */
 
 function PausedUserError(session) {
   this.name = 'PausedUserError';

--- a/src/app.js
+++ b/src/app.js
@@ -141,13 +141,17 @@ class Messenger extends EventEmitter {
       pageId: config.get('facebook.pageId')
     }));
 
-    this.app.get('/', (req, res) => {
-      res.send('👍');
+    this.app.post('/pause', bodyParser.json(), (req, res) => {
+      const userId = req.body.userId;
+      const paused = req.body.paused;
+      console.log(req.body)
+      // pausedUsers[userId] = paused
+      res.send('ok');
     });
 
-    this.app.get('/ping', (req, res) => {
-      res.send('pong');
-    });
+    // Boilerplate routes
+    this.app.get('/', (req, res) => res.send('👍'));
+    this.app.get('/ping', (req, res) => res.send('pong'));
   }
 
   start() {

--- a/src/app.js
+++ b/src/app.js
@@ -201,6 +201,10 @@ class Messenger extends EventEmitter {
         if (!pausedUsers) {
           pausedUsers = {};
         }
+        if (pausedUsers[messagingEvent.sender.id]) {
+          // TODO break promise chain
+        }
+
         // WISHLIST: logic to handle any thundering herd issues: https://en.wikipedia.org/wiki/Thundering_herd_problem
         if (session.profile) {
           return session;

--- a/src/app.js
+++ b/src/app.js
@@ -149,22 +149,19 @@ class Messenger extends EventEmitter {
       }
 
       // If we need to store more than `pausedUsers` in the future, use a
-      // general purpose map so we only have to make one trip to Redis
+      // general purpose Object so we only have to make one trip to Redis
       this.cache.get('pausedUsers')
-        .then((users/*: ?string[] */)/*: Set<string> */ => {
-          if (!users) {
-            users = [];
+        .then((pausedUsers/*: ?{[string]: number} */)/*: Promise<any> */ => {
+          if (!pausedUsers) {
+            pausedUsers = {};
           }
-          const usersSet = new Set(users);
           if (paused) {
-            usersSet.add(userId);
+            pausedUsers[userId] = Date.now();
           } else {
-            usersSet.delete(userId);
+            delete pausedUsers[userId];
           }
-          return usersSet;
-        })
-        .then((usersSet/*: Set<string> */)/*: Promise<any> */ => {
-          return this.cache.set('pausedUsers', Array.from(usersSet));
+          // TODO delete old entries from `pausedUsers`
+          return this.cache.set('pausedUsers', pausedUsers);
         })
         .then(() => res.send('ok'));
     });

--- a/src/app.js
+++ b/src/app.js
@@ -21,7 +21,7 @@ const PAUSE_TIMEOUT_MS = 1 * 3600 * 1000; // 1 hour
 const DEFAULT_GREETINGS_REGEX = /^(get started|good(morning|afternoon)|hello|hey|hi|hola|what's up)/i;
 const DEFAULT_HELP_REGEX = /^help\b/i;
 
-/*:: type Session = {_pageId: string|number, count: number, profile: ?Object} */
+/*:: type Session = {_pageId: string|number, count: number, profile: ?Object, paused?: number|false} */
 
 function PausedUserError(session) {
   this.name = 'PausedUserError';
@@ -150,35 +150,29 @@ class Messenger extends EventEmitter {
 
     this.app.post('/pause', bodyParser.json(), (req, res) => {
       const { userId, paused } = req.body;
-      const now = Date.now();
       if (!userId && paused === undefined) {
         res.sendStatus(400);
         return;
       }
 
-      // If we need to store more than `pausedUsers` in the future, use a
-      // general purpose Object so we only have to make one trip to Redis
-      this.cache.get('pausedUsers')
-        .then((pausedUsers/*: ?{[string]: number} */)/*: Promise<any> */ => {
-          if (!pausedUsers) {
-            pausedUsers = {};
+      const cacheKey = this.getCacheKey(userId);
+      this.cache.get(cacheKey)
+        .then((session/*: ?Session */)/*: Promise<Session> */ => {
+          if (!session) {
+            throw new Error("Can't pause unknown user");
           }
-          if (paused) {
-            pausedUsers[userId] = now;
-          } else {
-            delete pausedUsers[userId];
-          }
-          // Delete old entries to mitigate a DOS attack vector
-          Object.keys(pausedUsers).forEach((key) => {
-            // $FlowFixMe
-            if (now - pausedUsers[key] > PAUSE_TIMEOUT_MS) {
-              // $FlowFixMe
-              delete pausedUsers[key];
-            }
-          });
-          return this.cache.set('pausedUsers', pausedUsers);
+          session.paused = paused ? Date.now() : false;
+          return this.cache.set(userId, session);
         })
-        .then(() => res.send('ok'));
+        .then(() => res.send('ok'))
+        .catch((err) => {
+          if (err.message === "Can't pause unknown user") {
+            res.sendStatus(412);
+            return;
+          }
+
+          throw err;
+        });
     });
 
     // Boilerplate routes
@@ -198,15 +192,12 @@ class Messenger extends EventEmitter {
 
   routeEachMessage(messagingEvent/*: Object */, pageId/*: string */)/*: Promise<Session> */ {
     const cacheKey = this.getCacheKey(messagingEvent.sender.id);
-    return Promise.all([this.cache.get(cacheKey), this.cache.get('pausedUsers')])
-      .then(([session, pausedUsers]/*: [Session, Object] */) => {
-        if (!session) {
-          session = { _key: cacheKey, _pageId: pageId, count: 0, profile: null };
-        }
-        if (!pausedUsers) {
-          pausedUsers = {};
-        }
-        if (pausedUsers[messagingEvent.sender.id]) {
+    return this.cache.get(cacheKey)
+      // The cacheman-redis backend returns `null` instead of `undefined`
+      .then((cacheResult) => cacheResult || undefined)
+      .then((session/*: Session */ = { _key: cacheKey, _pageId: pageId, count: 0, profile: null }) => {
+        // $FlowFixMe Flow can't infer that session.paused is a number
+        if (session.paused && Date.now() - session.paused < PAUSE_TIMEOUT_MS) {
           throw new PausedUserError(session);
         }
 

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -665,7 +665,8 @@ describe('app', () => {
     it('provides a pause/ webhook for live person takeovers', () => {
       const messenger = new Messenger();
       const message = {
-        userId: 'foo'
+        userId: 'foo',
+        paused: true
       };
 
       return chai.request(messenger.app)
@@ -674,8 +675,10 @@ describe('app', () => {
         .send(message)
         .then((res) => {
           assert.equal(res.text, 'ok');
-          // TODO
-          // assert.equal(messenger.cache)
+          return messenger.cache.get('pausedUsers');
+        })
+        .then((pausedUsers) => {
+          assert.ok(pausedUsers.includes('foo'));
         });
     });
   });

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -680,7 +680,7 @@ describe('app', () => {
           return messenger.cache.get('pausedUsers');
         })
         .then((pausedUsers) => {
-          assert.ok(pausedUsers.includes('foo'));
+          assert.ok(pausedUsers.foo);
         });
     });
 

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -749,6 +749,24 @@ describe('app', () => {
       sandbox.stub(messenger, 'getPublicProfile').resolves({});
     });
 
+    it('ignores messages from paused user', () => {
+      const testCache = {
+        get(key) {
+          if (key === 'pausedUsers') {
+            return { teehee: 1 };
+          }
+
+          return Promise.resolve(null);
+        }
+      };
+      messenger = new Messenger({ cache: testCache });
+
+      return messenger.routeEachMessage(baseMessage)
+        .then((session) => {
+          assert.equal(session.count, 0);
+        });
+    });
+
     it('uses default session if cache returns falsey', () => {
       const nullCache = {
         get() {

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -661,8 +661,10 @@ describe('app', () => {
           done();
         });
     });
+  });
 
-    it('provides a pause/ webhook for live person takeovers', () => {
+  describe('pause/ webhook', () => {
+    it('provides a webhook for live person takeovers', () => {
       const messenger = new Messenger();
       const message = {
         userId: 'foo',
@@ -679,6 +681,16 @@ describe('app', () => {
         })
         .then((pausedUsers) => {
           assert.ok(pausedUsers.includes('foo'));
+        });
+    });
+
+    it('400s if body is bad', () => {
+      const messenger = new Messenger();
+
+      return chai.request(messenger.app)
+        .post('/pause')
+        .catch((err) => {
+          assert.equal(err.response.statusCode, 400);
         });
     });
   });

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -705,6 +705,28 @@ describe('app', () => {
         });
     });
 
+    it('cleans up old entries', () => {
+      const messenger = new Messenger();
+      const message = {
+        userId: 'foo',
+        paused: true
+      };
+
+      return messenger.cache.set('pausedUsers', { methuselah: 1 })
+        .then(() => chai.request(messenger.app)
+          .post('/pause')
+          .set('content-type', 'application/json')
+          .send(message))
+        .then((res) => {
+          assert.equal(res.text, 'ok');
+          return messenger.cache.get('pausedUsers');
+        })
+        .then((pausedUsers) => {
+          assert.ok(pausedUsers.foo);
+          assert.equal(pausedUsers.methuselah, undefined);
+        });
+    });
+
     it('400s if body is bad', () => {
       const messenger = new Messenger();
 

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -684,6 +684,27 @@ describe('app', () => {
         });
     });
 
+    it('can unpause a user', () => {
+      const messenger = new Messenger();
+      const message = {
+        userId: 'foo',
+        paused: false
+      };
+
+      return messenger.cache.set('pausedUsers', { foo: Date.now() })
+        .then(() => chai.request(messenger.app)
+          .post('/pause')
+          .set('content-type', 'application/json')
+          .send(message))
+        .then((res) => {
+          assert.equal(res.text, 'ok');
+          return messenger.cache.get('pausedUsers');
+        })
+        .then((pausedUsers) => {
+          assert.equal(pausedUsers.foo, undefined);
+        });
+    });
+
     it('400s if body is bad', () => {
       const messenger = new Messenger();
 

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -661,6 +661,23 @@ describe('app', () => {
           done();
         });
     });
+
+    it('provides a pause/ webhook for live person takeovers', () => {
+      const messenger = new Messenger();
+      const message = {
+        userId: 'foo'
+      };
+
+      return chai.request(messenger.app)
+        .post('/pause')
+        .set('content-type', 'application/json')
+        .send(message)
+        .then((res) => {
+          assert.equal(res.text, 'ok');
+          // TODO
+          // assert.equal(messenger.cache)
+        });
+    });
   });
 
   describe('routeEachMessage session', () => {


### PR DESCRIPTION
# Why are we doing this?

For most bots, users will want the ability to pause the bot just for a user so they can talk to them without the bot's automated responses filling the conversation. An example would be a customer service bot where the user signals they're ready to talk to a human. This adds a webhook that sets a cache key that will cause the bot to stop processing just for a user.

Follow Dashbot's guide: https://www.dashbot.io/sdk/pause

closes #67 

## Did you document your work?

I added a new section to the README for the http endpoints available.

## How can someone test these changes?

Steps to manually verify the change:

Just unit tests since this is the sdk.

1. `npm i`
2. `npm t`

## What possible risks or adverse effects are there?

* there's a new cache key, so that means you need another cache lookup, which increases the latency to the message

## What are the follow-up tasks?

* none

## Are there any known issues?

none

## Did the test coverage decrease?

new code is covered