### PR TITLE
Use fallback instead of exploding when failing to get a profile

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -405,8 +405,8 @@ class Messenger extends EventEmitter {
 
   emitOptionalEvents(event, senderId, session, text) {
     if (this.options.emitGreetings && this.greetings.test(text)) {
-      const firstName = session.profile && session.profile.first_name.trim() || '';
-      const surName = session.profile && session.profile.last_name.trim() || '';
+      const firstName = session.profile && session.profile.first_name && session.profile.first_name.trim() || '';
+      const surName = session.profile && session.profile.last_name && session.profile.last_name.trim() || '';
       const fullName = `${firstName} ${surName}`;
 
       this.emit('text.greeting', new Response(this, { event, senderId, session, firstName, surName, fullName }));

--- a/src/app.js
+++ b/src/app.js
@@ -281,9 +281,8 @@ class Messenger extends EventEmitter {
     this.pageSend(pageId, senderId, messageData);
   }
 
-  getPublicProfile(senderId/*: number */, pageId/*: string|void */)/*: Promise<Object> */ {
-    // TODO make `pageId` required, then simplify. `getPublicProfile` is only internal right now
-    const pageAccessToken = this.pages[pageId || config.get('facebook.pageId')];
+  getPublicProfile(senderId/*: number */, pageId/*: string */)/*: Promise<Object> */ {
+    const pageAccessToken = this.pages[pageId];
     if (!pageAccessToken) {
       return Promise.reject(
         new Error(`getPublicProfile: Missing page config for: ${pageId || ''}`)

--- a/src/app.js
+++ b/src/app.js
@@ -209,6 +209,11 @@ class Messenger extends EventEmitter {
           .then((profile) => {
             session.profile = profile;
             return session;
+          })
+          .catch((err) => {
+            logError(err.message);
+            session.profile = {};
+            return session;
           });
       })
       .then((session) => {
@@ -280,7 +285,9 @@ class Messenger extends EventEmitter {
     // TODO make `pageId` required, then simplify. `getPublicProfile` is only internal right now
     const pageAccessToken = this.pages[pageId || config.get('facebook.pageId')];
     if (!pageAccessToken) {
-      throw new Error(`Missing page config for: ${pageId || ''}`);
+      return Promise.reject(
+        new Error(`getPublicProfile: Missing page config for: ${pageId || ''}`)
+      );
     }
     const options = {
       json: true,

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -139,13 +139,6 @@ describe('app', () => {
   });
 
   describe('getPublicProfile', () => {
-    it('gets public profile with deprecated arguments', () => {
-      return messenger.getPublicProfile(12345)
-        .then((profile) => {
-          assert.ok(profile);
-        });
-    });
-
     it('gets public profile', () => {
       const myMessenger = new Messenger({ pages: { 1337: '1337accesstoken' } });
       return myMessenger.getPublicProfile(12345, 1337)

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -476,11 +476,22 @@ describe('app', () => {
     const senderId = 'guy-hoozdis';
 
     it('returns a truthy value when it emits a text.greeting event', (done) => {
-      messenger.once('text.greeting', (payload) => {
-        assert.equal(payload.senderId, senderId);
+      messenger.once('text.greeting', (res) => {
+        assert.equal(res.senderId, senderId);
+        assert.equal(res.firstName, '');
         done();
       });
       assert.ok(messenger.emitOptionalEvents({}, senderId, {}, 'hello'));
+    });
+
+    it('handles a text.greeting with an empty profile event', (done) => {
+      const session = { profile: {} };
+      messenger.once('text.greeting', (res) => {
+        assert.equal(res.senderId, senderId);
+        assert.equal(res.firstName, '');
+        done();
+      });
+      assert.ok(messenger.emitOptionalEvents({}, senderId, session, 'hello'));
     });
 
     it('returns a truthy value when it emits a text.help event', (done) => {


### PR DESCRIPTION
## Why are we doing this?

The bot tries to get a profile, but it's a convenience, not a requirement. If for some reason the profile can't be loaded, it should not be a show stopper. There are already cases where we can't get a profile (bot messing a bot) where we fallback to an empty object and log a warning.

This PR also implements a longstanding related TODO and fixes the fallback case for the greeting message.

## Did you document your work?

No README updates necessary. Code comments and type defs are updated.

## How can someone test these changes?

Steps to manually verify the change:

1. `npm t`

## What possible risks or adverse effects are there?

* none. If someone was relying on this obscure code blowing up, that should be fixed on their side

## What are the follow-up tasks?

* none

## Are there any known issues?

none

## Did the test coverage decrease?

increases, the profile fetching logic inside `routeEachMessage` wasn't covered before.