### PR TITLE
Enable 'referral' event for Messenger Code scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ In addition, `data` contains these attributes on specific events:
 * `postback` For conversation, use the `text` event, this is for the raw message sent via a postback
   * `payload` Postback content: `event.postback.payload`
 * `referral` Fires when a user scans your [Messenger code]
-  * `referral` Referral content
+  * `referral` Referral content (from Facebook):
     * `referral.ref` A custom `ref` for a parametric code
     * `referral.source` `MESSENGER_CODE`
     * `referral.type` `OPEN_THREAD`

--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ In addition, `data` contains these attributes on specific events:
   * `payload` Quick reply content: `event.quick_reply.payload`
 * `postback` For conversation, use the `text` event, this is for the raw message sent via a postback
   * `payload` Postback content: `event.postback.payload`
+* `referral` Fires when a user scans your [Messenger code]
+  * `referral` Referral content
+    * `referral.ref` A custom `ref` for a parametric code
+    * `referral.source` `MESSENGER_CODE`
+    * `referral.type` `OPEN_THREAD`
+
+[Messenger code]: https://developers.facebook.com/docs/messenger-platform/discovery/messenger-codes/
 
 #### Other Events
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1342,9 +1342,9 @@
       }
     },
     "flow-bin": {
-      "version": "0.57.3",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.57.3.tgz",
-      "integrity": "sha512-bbB7KLR1bLS0CvHSsKseOGFF6iI2N9ocL14EQv8Hng28ZksD0gNRzR2JopqA3WGrQYJukDU1W4ZuKoBaRuElFA==",
+      "version": "0.58.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.58.0.tgz",
+      "integrity": "sha512-jMImubdtZxLafc0EXZVCtOIJVknqGrruClPbol6kZ1oVQioMWu95iiKQMaSDJ78F4TjYuZCbqsdZ4LSI7TSsjA==",
       "dev": true
     },
     "foreach": {
@@ -1869,9 +1869,9 @@
       }
     },
     "just-extend": {
-      "version": "1.1.26",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.26.tgz",
-      "integrity": "sha512-IIG0FXHB/XpUZ7vGbktoc2EGsF+fLHJ1tU+vaqoKkVRBwH2FDxLTmkGkSp0XHRp6Y3KGZPIldH1YW8lOluGYrA==",
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
       "dev": true
     },
     "kind-of": {
@@ -2121,7 +2121,7 @@
       "dev": true,
       "requires": {
         "formatio": "1.2.0",
-        "just-extend": "1.1.26",
+        "just-extend": "1.1.27",
         "lolex": "1.6.0",
         "path-to-regexp": "1.7.0",
         "text-encoding": "0.6.4"
@@ -2791,9 +2791,9 @@
       "dev": true
     },
     "sinon": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.0.2.tgz",
-      "integrity": "sha512-4mUsjHfjrHyPFGDTtNJl0q8cv4VOJGvQykI1r3fnn05ys0sQL9M1Y+DyyGNWLD2PMcoyqjJ/nFDm4K54V1eQOg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.1.1.tgz",
+      "integrity": "sha512-l+74gYEaCH967jIfuLCsBxmAW88/6+y+dzr6HJqOuKdGFYA5JQWOxYcyF6aBd49v8/QOIIQYwzcfaTP9FQawdg==",
       "dev": true,
       "requires": {
         "diff": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -48,10 +48,10 @@
     "eslint": "^4.10.0",
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-mocha": "^4.9.0",
-    "flow-bin": "^0.57.3",
+    "flow-bin": "^0.58.0",
     "istanbul": "^0.4.5",
     "mocha": "^4.0.1",
-    "sinon": "^4.0.2",
+    "sinon": "^4.1.1",
     "supertest": "^3.0.0"
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -428,7 +428,7 @@ class Messenger extends EventEmitter {
     const senderId = event.sender.id;
     const payload = event.referral;
     debug("onReferral for user:%s with payload '%s'", senderId, payload);
-    this.emit('referral', new Response(this, { event, senderId, session, source: 'referral', referral: payload }));
+    this.emit('referral', new Response(this, { event, senderId, session, referral: payload }));
   }
 
   // HELPERS

--- a/src/app.js
+++ b/src/app.js
@@ -257,6 +257,8 @@ class Messenger extends EventEmitter {
           this.onPostback(messagingEvent, session);
         } else if (messagingEvent.read) {
           debug('incoming read event');
+        } else if (messagingEvent.referral) {
+          this.onReferral(messagingEvent, session);
         } else {
           debug('incoming unknown messagingEvent: %o', messagingEvent);
         }
@@ -413,13 +415,20 @@ class Messenger extends EventEmitter {
     // The 'payload' param is a developer-defined field which is set in a postback
     // button for Structured Messages.
     const payload = event.postback.payload;
-    debug("onPostback for user:%d with payload '%s'", senderId, payload);
+    debug("onPostback for user:%s with payload '%s'", senderId, payload);
     this.emit('postback', new Response(this, { event, senderId, session, payload }));
 
     if (this.emitOptionalEvents(event, senderId, session, payload)) {
       return;
     }
     this.emit('text', new Response(this, { event, senderId, session, source: 'postback', text: payload, normalizedText: this.normalizeString(payload) }));
+  }
+
+  onReferral(event, session/*: Session */) {
+    const senderId = event.sender.id;
+    const payload = event.referral;
+    debug("onReferral for user:%s with payload '%s'", senderId, payload);
+    this.emit('referral', new Response(this, { event, senderId, session, source: 'referral', referral: payload }));
   }
 
   // HELPERS

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -438,15 +438,6 @@ describe('app', () => {
       messenger.onMessage(event, session);
     });
 
-    it('emits "referral" event', () => {
-      messenger.once('message.referral', (payload) => {
-        assert.equal(payload.senderId, 'senderId');
-      });
-
-      const event = JSON.parse('{"recipient":{"id":"910102032453986"},"timestamp":1509732003196,"sender":{"id":"1250872178269050"},"referral":{"ref":"R1C1","source":"MESSENGER_CODE","type":"OPEN_THREAD"}}');
-      messenger.onMessage(event, session);
-    });
-
     it('emits "greeting" event', () => {
       const text = "hello, is it me you're looking for?";
       const event = Object.assign({}, baseEvent, { message: { text: text } });
@@ -933,5 +924,16 @@ describe('app', () => {
           assert.equal(session.source, 'foo this should not change');
         })
     );
+
+    it('emits "referral" event', (done) => {
+      messenger.once('referral', (payload) => {
+        assert.equal(payload.senderId, '1250872178269050');
+        assert.equal(payload.referral.ref, 'R1C1');
+        done();
+      });
+
+      const message = JSON.parse('{"recipient":{"id":"910102032453986"},"timestamp":1509732003196,"sender":{"id":"1250872178269050"},"referral":{"ref":"R1C1","source":"MESSENGER_CODE","type":"OPEN_THREAD"}}');
+      messenger.routeEachMessage(message);
+    });
   });
 });

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -261,6 +261,7 @@ describe('app', () => {
 
   describe('onAuth', function () {
     this.timeout(100);
+    // WISHLIST transition `baseEvent` to fixtures based on real data
     const baseEvent = {
       sender: { id: 'senderId' },
       recipient: { id: 'recipientId' },
@@ -434,6 +435,15 @@ describe('app', () => {
         }
       });
 
+      messenger.onMessage(event, session);
+    });
+
+    it('emits "referral" event', () => {
+      messenger.once('message.referral', (payload) => {
+        assert.equal(payload.senderId, 'senderId');
+      });
+
+      const event = JSON.parse('{"recipient":{"id":"910102032453986"},"timestamp":1509732003196,"sender":{"id":"1250872178269050"},"referral":{"ref":"R1C1","source":"MESSENGER_CODE","type":"OPEN_THREAD"}}');
       messenger.onMessage(event, session);
     });
 


### PR DESCRIPTION
## Why are we doing this?

Messenger has "parametric messenger codes". When these visual codes are scanned, the bot is supposed to be able to respond. Facebook created a new `referral` event for this, even though it's the same thing as `postback` 🤷‍♂️ . This PR adds support for this new event, following the naming conventions for the other events.

https://developers.facebook.com/docs/messenger-platform/discovery/messenger-codes/

## Did you document your work?

README has the new event and how to use it.

## How can someone test these changes?

Steps to manually verify the change:

1. `npm i`
1. `npm t`

## What possible risks or adverse effects are there?

* none

## What are the follow-up tasks?

* roll a new minor release
* migrate tests to use real data (todo in the codebase)

## Are there any known issues?

none

## Did the test coverage decrease?

new code is covered, albeit not quite unit level, not quite integration level, but tests with this pattern should be easier to maintain.
