### PR TITLE
Add messaging_type for future compatibility

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports = {
     '@condenast/eslint-config-condenast/rules/ext/mocha'
   ],
   rules: {
+    complexity: ['warn', 20],
     'no-bitwise': ['error', { 'int32Hint': true }]
   }
-}
+};

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,6 +14,9 @@ help:
 
 .PHONY: help Makefile
 
+watch:
+	cd .. && sphinx-autobuild --watch src docs docs/_build/html
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,10 +14,10 @@ help:
 
 .PHONY: help Makefile
 
-watch:
-	cd .. && sphinx-autobuild --watch src docs docs/_build/html
-
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+watch:
+	cd .. && sphinx-autobuild --watch src docs docs/_build/html

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
+sphinx-autobuild
 sphinx-js

--- a/src/app.js
+++ b/src/app.js
@@ -499,7 +499,14 @@ class Messenger extends EventEmitter {
   }
 
   /**
-   * Send a response to a user at a page. You probably want to use :meth:`Response.reply` instead
+   * Send a response to a user at a page.
+   * This is the long way of sending a message.
+   * You probably want to use shortcut :meth:`Response.reply` instead.
+   *
+   * The SDK sets the `messaging_type <https://developers.facebook.com/docs/messenger-platform/send-messages#messaging_types>`_ for all messages to ``RESPONSE``.
+   * because all messages are sent in response to a user action.
+   * It's possible to use send other message types but setting another
+   * ``messaging_type`` is currently unsupported.
    * @param  {string} pageId Page ID
    * @param  {string} recipientId Recipient ID
    * @param  {Object} responseMessage The response message to send back
@@ -519,8 +526,6 @@ class Messenger extends EventEmitter {
           id: recipientId
         },
         message: responseMessage,
-        // We assume
-        // https://developers.facebook.com/docs/messenger-platform/send-messages#messaging_types
         messaging_type: 'RESPONSE' // options: RESPONSE, UPDATE, MESSAGE_TAG, NON_PROMOTIONAL_SUBSCRIPTION
       }
     };

--- a/src/app.js
+++ b/src/app.js
@@ -518,7 +518,10 @@ class Messenger extends EventEmitter {
         recipient: {
           id: recipientId
         },
-        message: responseMessage
+        message: responseMessage,
+        // We assume
+        // https://developers.facebook.com/docs/messenger-platform/send-messages#messaging_types
+        messaging_type: 'RESPONSE' // options: RESPONSE, UPDATE, MESSAGE_TAG, NON_PROMOTIONAL_SUBSCRIPTION
       }
     };
     debug('message.send: %j', options);

--- a/src/app.js
+++ b/src/app.js
@@ -503,10 +503,11 @@ class Messenger extends EventEmitter {
    * This is the long way of sending a message.
    * You probably want to use shortcut :meth:`Response.reply` instead.
    *
-   * The SDK sets the `messaging_type <https://developers.facebook.com/docs/messenger-platform/send-messages#messaging_types>`_ for all messages to ``RESPONSE``.
-   * because all messages are sent in response to a user action.
-   * It's possible to use send other message types but setting another
-   * ``messaging_type`` is currently unsupported.
+   * The SDK sets the `messaging_type <https://developers.facebook.com/docs/messenger-platform/send-messages#messaging_types>`_
+   * for all messages to ``RESPONSE`` because most users will only send
+   * messages in response to their users' actions.
+   * While it's possible to use the SDK to send other message types,
+   * setting another ``messaging_type`` is currently unsupported.
    * @param  {string} pageId Page ID
    * @param  {string} recipientId Recipient ID
    * @param  {Object} responseMessage The response message to send back

--- a/src/app.js
+++ b/src/app.js
@@ -456,7 +456,6 @@ class Messenger extends EventEmitter {
   // HELPERS
   //////////
 
-  // eslint-disable-next-line complexity
   emitOptionalEvents(event, senderId, session, text) {
     if (this.options.emitGreetings && this.greetings.test(text)) {
       const firstName = session.profile && session.profile.first_name && session.profile.first_name.trim() || '';

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -617,7 +617,7 @@ describe('app', () => {
     });
   });
 
-  describe('send', () => {
+  describe('pageSend', () => {
     beforeEach(() => {
       messenger.pageSend.restore();
       sandbox.stub(reqPromise, 'post').resolves({});
@@ -632,13 +632,14 @@ describe('app', () => {
       }
     });
 
-    it('passes sender id and message', () => {
+    it('passes required elements', () => {
       const myMessenger = new Messenger({ pages: { 1337: '1337accesstoken' } });
       return myMessenger.pageSend(1337, 'senderId', { foo: 'bar' })
         .then(() => {
           assert.equal(reqPromise.post.args[0][0].qs.access_token, '1337accesstoken');
           assert.equal(reqPromise.post.args[0][0].json.recipient.id, 'senderId');
           assert.deepEqual(reqPromise.post.args[0][0].json.message, { foo: 'bar' });
+          assert.deepEqual(reqPromise.post.args[0][0].json.messaging_type, 'RESPONSE');
         });
     });
 


### PR DESCRIPTION
## Why are we doing this?

Messenger's docs say:

> As of the release of Messenger Platform v2.2, we are requesting developers to include the messaging_type property in all message sends.
> Beginning May 7, 2018, this property will be required for all message sends. After this date, message sends that do not include messaging_type will return an error and not be delivered.

https://developers.facebook.com/docs/messenger-platform/send-messages#messaging_types

This adds that field to the api calls so projects built on this won't break.

closes #86 

## Did you document your work?

Sphinx docs are updated.

## How can someone test these changes?

Steps to manually verify the change:

1. `npm i`
2. `npm t`

In your docs Python environment...
1. `cd docs && pip install requirements.txt`
2. `cd docs && make watch`
3. view api docs http://localhost:8000/api.html

I also did a `npm link launch-vehicle-fbm` to a test bot and saw this response:
```
  messenger message.send: {"uri":"https://graph.facebook.com/v2.8/me/messages","qs":{"access_token":"EAAQbfb7mOoUBAHDosOZCUtvCyVwgFfczdsRbMXoCn9272DfsBNQttqPtjWGV3FRiNGYD6eDH4jgzKkZCZCfvvsVsDcCHwLRs5Oqyzn5DcZAbR1Huzy7oG1WaWk36LgLa26fh2ufN1oTdZAdEFcczcNDrkcLEl6weGIcR0cf52hwZDZD"},"json":{"dashbotTemplateId":"right","recipient":{"id":"1250872178269050"},"message":{"text":"😽"},"messaging_type":"RESPONSE"}} +1ms
  messenger message.send:SUCCESS message id: mid.$cAAM7u6QjuXRnHMMQAFg633HFE0fQ to user:1250872178269050 +852ms
```

## What possible risks or adverse effects are there?

None.

## What are the follow-up tasks?

* Add a way for users to override `messaging_type`

## Are there any known issues?

None


## Did the test coverage decrease?

stays the same, new shape of the output is tested.